### PR TITLE
fix: Improve multi-line tag handling 

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -205,6 +205,48 @@ func TestMultiLineHLSElements_StreamInf(t *testing.T) {
 	assert.Equal(t, "30", node.HLSElement.Attrs["FRAME-RATE"])
 }
 
+func TestCompleteMultivariantPlaylist(t *testing.T) {
+	playlist := `#EXTM3U
+							#EXT-X-VERSION:3
+							## Created with Unified Streaming Platform  (version=1.14.4-30793)
+
+							# variants
+							#EXT-X-STREAM-INF:BANDWIDTH=759000,AVERAGE-BANDWIDTH=690000,CODECS=\"mp4a.40.2,avc1.64001F\",RESOLUTION=640x360,FRAME-RATE=30
+							coelhodai-audio_1=96000-video=558976.m3u8?dvr_window_length=600
+							#EXT-X-STREAM-INF:BANDWIDTH=759000,AVERAGE-BANDWIDTH=690000,CODECS=\"mp4a.40.2,avc1.64001F\",RESOLUTION=720x480,FRAME-RATE=30
+							coelhodai-audio_1=96000-video=123456.m3u8?dvr_window_length=600`
+
+	p, err := setupPlaylist(playlist)
+
+	assert.NoError(t, err)
+	assert.Equal(t, p.Head.HLSElement.Name, "M3u8Identifier")
+	assert.Equal(t, p.Tail.HLSElement.Name, "StreamInf")
+	assert.Equal(t, len(p.Variants()), 2)
+	assert.Nil(t, p.CurrentSegment)
+	assert.Nil(t, p.CurrentStreamInf)
+}
+
+func TestCompleteMediaPlaylist(t *testing.T) {
+	playlist := `#EXTM3U
+							#EXT-X-VERSION:3
+							## Created with Unified Streaming Platform  (version=1.14.4-30793)
+
+							# variants
+							#EXT-X-STREAM-INF:BANDWIDTH=759000,AVERAGE-BANDWIDTH=690000,CODECS=\"mp4a.40.2,avc1.64001F\",RESOLUTION=640x360,FRAME-RATE=30
+							coelhodai-audio_1=96000-video=558976.m3u8?dvr_window_length=600
+							#EXT-X-STREAM-INF:BANDWIDTH=759000,AVERAGE-BANDWIDTH=690000,CODECS=\"mp4a.40.2,avc1.64001F\",RESOLUTION=720x480,FRAME-RATE=30
+							coelhodai-audio_1=96000-video=123456.m3u8?dvr_window_length=600`
+
+	p, err := setupPlaylist(playlist)
+
+	assert.NoError(t, err)
+	assert.Equal(t, p.Head.HLSElement.Name, "M3u8Identifier")
+	assert.Equal(t, p.Tail.HLSElement.Name, "StreamInf")
+	assert.NotEqual(t, p.Variants(), 0)
+	assert.Nil(t, p.CurrentSegment)
+	assert.Nil(t, p.CurrentStreamInf)
+}
+
 func TestParsePlaylist(t *testing.T) {
 	type testCaseParams struct {
 		name           string

--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -33,9 +33,8 @@ type Playlist struct {
 func NewPlaylist() *Playlist {
 	return &Playlist{
 		DoublyLinkedList: new(internal.DoublyLinkedList),
-		CurrentNode:      new(internal.Node),
-		CurrentSegment:   new(ExtInfData),
-		CurrentStreamInf: new(StreamInfData),
+		CurrentSegment:   nil,
+		CurrentStreamInf: nil,
 		ProgramDateTime:  *new(time.Time),
 		MediaSequence:    0,
 		SegmentsCounter:  0,

--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -186,15 +186,12 @@ func GetExtInfData(duration string, playlistMediaSequence, playlistSegmentsCount
 	}
 }
 
-// Handles HLS Elements whose format in manifest are multi-line:
-//
-//   - ExtInf (tag + uri)
-//   - StreamInf (tag + uri)
+// Handles HLS Elements whose format in manifest are multi-line: tag + uri.
+// The URI line that follows the EXT-X-STREAM-INF and EXTINF tags is REQUIRED.
 func HandleMultiLineHLSElements(line string, p *Playlist) error {
 	switch {
-	// Handle HLS segment lines
-	case p.CurrentSegment != nil && strings.HasSuffix(line, ".ts"):
-		p.CurrentSegment.URI = line
+	// Handle EXTINF
+	case p.CurrentSegment != nil:
 		p.Insert(&internal.Node{
 			HLSElement: &internal.HLSElement{
 				Name: "ExtInf",
@@ -211,21 +208,19 @@ func HandleMultiLineHLSElements(line string, p *Playlist) error {
 		p.CurrentSegment = nil
 		return nil
 
-	// Handle HLS media playlist lines
-	case p.CurrentStreamInf != nil && strings.HasSuffix(line, ".m3u8"):
-		p.CurrentStreamInf.URI = line
-		attrs := map[string]string{
-			"BANDWIDTH":         p.CurrentStreamInf.Bandwidth,
-			"AVERAGE-BANDWIDTH": p.CurrentStreamInf.AverageBandwidth,
-			"CODECS":            strings.Join(p.CurrentStreamInf.Codecs, ","),
-			"RESOLUTION":        p.CurrentStreamInf.Resolution,
-			"FRAME-RATE":        p.CurrentStreamInf.FrameRate,
-		}
+	// Handle EXT-X-STREAM-INF
+	case p.CurrentStreamInf != nil:
 		p.Insert(&internal.Node{
 			HLSElement: &internal.HLSElement{
-				Name:  "StreamInf",
-				Attrs: attrs,
-				URI:   line,
+				Name: "StreamInf",
+				URI:  line,
+				Attrs: map[string]string{
+					"BANDWIDTH":         p.CurrentStreamInf.Bandwidth,
+					"AVERAGE-BANDWIDTH": p.CurrentStreamInf.AverageBandwidth,
+					"CODECS":            strings.Join(p.CurrentStreamInf.Codecs, ","),
+					"RESOLUTION":        p.CurrentStreamInf.Resolution,
+					"FRAME-RATE":        p.CurrentStreamInf.FrameRate,
+				},
 			},
 		})
 		p.CurrentStreamInf = nil

--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -41,6 +41,22 @@ func NewPlaylist() *Playlist {
 	}
 }
 
+func (p *Playlist) Print() {
+	if p.Head == nil || p.Tail == nil {
+		log.Warn().Msg("playlist is empty")
+		return
+	}
+
+	current := p.Head
+	for current != nil {
+		fmt.Printf(">>>>>>>>> Node: %+v\n", current)
+		if current.HLSElement != nil {
+			fmt.Printf("HLSElement: %+v\n", current.HLSElement)
+		}
+		current = current.Next
+	}
+}
+
 func (p *Playlist) VersionValue() string {
 	node, found := p.Find("Version")
 	if !found {

--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -21,7 +21,6 @@ var (
 
 type Playlist struct {
 	*internal.DoublyLinkedList
-	CurrentNode      *internal.Node
 	CurrentSegment   *ExtInfData
 	CurrentStreamInf *StreamInfData
 	ProgramDateTime  time.Time


### PR DESCRIPTION
## What type of PR is this?

<!-- Select the type of Pull Request below. You may select more than one category if applicable. -->
<!-- If this PR is a draft, remember to create it as such. -->

- [ ] 🧹 Refactor: Improves codebase readability and perfomance without adding a new functionality.
- [ ] 💎 Feature: Introduces a new functionality.
- [x] 🐛 Bug Fix: Patches a bug in the codebase.
- [ ] 📖 Documentation: Adds or updates documentation files.
- [ ] 🧪 CI: Updates CI/CD configuration.
- [ ] 🔙 Revert: Rollbacks previous changes.

## Description

<!-- Add a proper description to your pull request here. List the changes that were implemented and explain the reasoning behind them. -->

### Fixing StreamInf and ExtInf Decoding

The method for handling multi-line tags was failing for `StreamInf` and `ExtInf` URIs that had query params after the extensions `.m3u8` or `.ts`. 

- Updated the `HandleMultiLineHLSElements` method to fix the conditional clauses for `StreamInf` and `ExtInf` nodes.
- Added a unit test to consider variants with query strings in the `decode_test.go` suite.

To verify whether the current manifest line is an URI for the tags `StreamInf` or `ExtInf`, it is enough to verify if the `Playlist` elements `CurrentStreamInf` or `CurrentSegment` are not nil. These elements are initialized with a nil value, but are updated by the `StreamInfParser` and `ExtInfParser` when the corresponding tags are read from the manifest.  

Therefore, in the `HandleMultiLineHLSElements` method, if these elements are not nil, we know the previous line was a `StreamInf` or `ExtInf` tag and the current line is its URI. At this moment, the `StreamInf` and `ExtInf` nodes are inserted into the `Playlist` and the `Playlist` elements `CurrentStreamInf` or `CurrentSegment` become nil again.

### General Refactoring

- Delete unused `Playlist` field `CurrentNode`.

## Related Tickets & Documents

<!-- Describe any relevant related tickets or issues here. When necessary, add further documentation to elaborate on the issue at hand. -->

- **Related Issue:** N/A
- **Closes:** N/A

## Added/Updated Tests?

<!-- We encourage you to keep the code coverage percentage at 80% and above. -->

- [x] Yes
- [ ] No, and this is why: _N/A_
- [ ] I need help with writing tests