### PR TITLE
Log error when cue out tag is invalid

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -118,13 +118,14 @@ func TestCueOutParser(t *testing.T) {
 	assert.Equal(t, "30", node.HLSElement.Attrs["#EXT-X-CUE-OUT"])
 }
 
-func TestInvalidCueOut(t *testing.T) {
+func TestCueOutParserWithoutDuration(t *testing.T) {
 	playlist := "#EXT-X-CUE-OUT"
 	p, err := setupPlaylist(playlist)
 	assert.NoError(t, err)
 
-	_, ok := p.Find("CueOut")
-	assert.False(t, ok)
+	node, ok := p.Find("CueOut")
+	assert.True(t, ok)
+	assert.Equal(t, "0", node.HLSElement.Attrs["#EXT-X-CUE-OUT"])
 }
 
 func TestCueInParser(t *testing.T) {

--- a/decode_test.go
+++ b/decode_test.go
@@ -118,6 +118,15 @@ func TestCueOutParser(t *testing.T) {
 	assert.Equal(t, "30", node.HLSElement.Attrs["#EXT-X-CUE-OUT"])
 }
 
+func TestInvalidCueOut(t *testing.T) {
+	playlist := "#EXT-X-CUE-OUT"
+	p, err := setupPlaylist(playlist)
+	assert.NoError(t, err)
+
+	_, ok := p.Find("CueOut")
+	assert.False(t, ok)
+}
+
 func TestCueInParser(t *testing.T) {
 	playlist := strings.Join([]string{
 		"#EXT-X-DATERANGE:SCTE35-IN=0xFF0000,ID=\"break1\",START-DATE=\"2025-01-01T00:00:00Z\"",

--- a/tags/others/others.go
+++ b/tags/others/others.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dlclark/regexp2"
 	"github.com/globocom/go-m3u8/internal"
 	pl "github.com/globocom/go-m3u8/playlist"
+	"github.com/rs/zerolog/log"
 )
 
 var (
@@ -62,7 +63,8 @@ func (p EventCueOutParser) Parse(tag string, playlist *pl.Playlist) error {
 		})
 		return nil
 	}
-	return fmt.Errorf("invalid cue out tag: %s", tag)
+	log.Error().Msgf("invalid cue out tag: %s", tag)
+	return nil
 }
 
 func (p EventCueInParser) Parse(tag string, playlist *pl.Playlist) error {

--- a/tags/others/others.go
+++ b/tags/others/others.go
@@ -53,17 +53,22 @@ func (p USPTimestampMapParser) Parse(tag string, playlist *pl.Playlist) error {
 }
 
 func (p EventCueOutParser) Parse(tag string, playlist *pl.Playlist) error {
+	duration := "0"
 	parts := strings.SplitN(tag, ":", 2)
+
 	if len(parts) > 1 {
-		playlist.Insert(&internal.Node{
-			HLSElement: &internal.HLSElement{
-				Name:  "CueOut",
-				Attrs: map[string]string{EventCueOutTag: strings.TrimSpace(parts[1])},
-			},
-		})
-		return nil
+		duration = strings.TrimSpace(parts[1])
+	} else {
+		log.Error().Msgf("invalid cue out tag: %s", tag)
 	}
-	log.Error().Msgf("invalid cue out tag: %s", tag)
+
+	playlist.Insert(&internal.Node{
+		HLSElement: &internal.HLSElement{
+			Name:  "CueOut",
+			Attrs: map[string]string{EventCueOutTag: duration},
+		},
+	})
+
 	return nil
 }
 


### PR DESCRIPTION
## What type of PR is this?

<!-- Select the type of Pull Request below. You may select more than one category if applicable. -->
<!-- If this PR is a draft, remember to create it as such. -->

- [ ] 🧹 Refactor: Improves codebase readability and perfomance without adding a new functionality.
- [ ] 💎 Feature: Introduces a new functionality.
- [x] 🐛 Bug Fix: Patches a bug in the codebase.
- [ ] 📖 Documentation: Adds or updates documentation files.
- [ ] 🧪 CI: Updates CI/CD configuration.
- [ ] 🔙 Revert: Rollbacks previous changes.

## Description

<!-- Add a proper description to your pull request here. List the changes that were implemented and explain the reasoning behind them. -->

The CUE OUT tag parse function no longer returns an error when it cannot find the break duration value.

We will not always have this value and we need to handle it when it is empty. So this PR adjusts it to return nil when it cannot find it and we log the error to find out the problem.

## Related Tickets & Documents

<!-- Describe any relevant related tickets or issues here. When necessary, add further documentation to elaborate on the issue at hand. -->

- **Related Issue:** N/A
- **Closes:** N/A

## Added/Updated Tests

<!-- We encourage you to keep the code coverage percentage at 80% and above. -->

- [x] Yes
- [ ] No, and this is why: _N/A_
- [ ] I need help with writing tests