### PR TITLE
Create IsSameMediaSequenceFromBreak and IsCueInMediaSequenceFromBreak method

### DIFF
--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -241,7 +241,7 @@ func (p *Playlist) FindPreviousSegment(node *internal.Node) *internal.Node {
 }
 
 // Returns true if the given node is a segment (#EXTINF), false otherwise.
-func (p *Playlist) IsSegment(node *internal.Node) bool {
+func IsSegment(node *internal.Node) bool {
 	return node.HLSElement.Name == "ExtInf"
 }
 

--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -240,6 +240,18 @@ func (p *Playlist) FindPreviousSegment(node *internal.Node) *internal.Node {
 	return nil
 }
 
+// Returns the next segment (#EXTINF) after the given node, or nil if none exists.
+func (p *Playlist) FindNextSegment(node *internal.Node) *internal.Node {
+	current := node.Next
+	for current != nil {
+		if current.HLSElement.Name == "ExtInf" {
+			return current
+		}
+		current = current.Next
+	}
+	return nil
+}
+
 // Returns true if the given node is a segment (#EXTINF), false otherwise.
 func IsSegment(node *internal.Node) bool {
 	return node.HLSElement.Name == "ExtInf"

--- a/playlist/playlist_test.go
+++ b/playlist/playlist_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/globocom/go-m3u8/internal"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/globocom/go-m3u8/playlist"
+	p "github.com/globocom/go-m3u8/playlist"
 )
 
 func TestVersionValue(t *testing.T) {
@@ -379,8 +379,8 @@ func TestIsSegment(t *testing.T) {
 	segmentNode := playlistInstance.Segments()[0]
 	versionNode, _ := playlistInstance.VersionTag()
 
-	isSegment := playlist.IsSegment(segmentNode)
-	isNotSegment := playlist.IsSegment(versionNode)
+	isSegment := p.IsSegment(segmentNode)
+	isNotSegment := p.IsSegment(versionNode)
 
 	assert.True(t, isSegment)
 	assert.False(t, isNotSegment)

--- a/playlist/playlist_test.go
+++ b/playlist/playlist_test.go
@@ -373,11 +373,11 @@ func TestFindPreviousSegment(t *testing.T) {
 
 func TestIsSegment(t *testing.T) {
 	file, _ := os.Open("./../mocks/media/media.m3u8")
-	playlistInstance, err := m3u8.ParsePlaylist(file)
+	playlist, err := m3u8.ParsePlaylist(file)
 	assert.NoError(t, err)
 
-	segmentNode := playlistInstance.Segments()[0]
-	versionNode, _ := playlistInstance.VersionTag()
+	segmentNode := playlist.Segments()[0]
+	versionNode, _ := playlist.VersionTag()
 
 	isSegment := p.IsSegment(segmentNode)
 	isNotSegment := p.IsSegment(versionNode)

--- a/playlist/playlist_test.go
+++ b/playlist/playlist_test.go
@@ -7,6 +7,8 @@ import (
 	m3u8 "github.com/globocom/go-m3u8"
 	"github.com/globocom/go-m3u8/internal"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/globocom/go-m3u8/playlist"
 )
 
 func TestVersionValue(t *testing.T) {
@@ -371,11 +373,11 @@ func TestFindPreviousSegment(t *testing.T) {
 
 func TestIsSegment(t *testing.T) {
 	file, _ := os.Open("./../mocks/media/media.m3u8")
-	playlist, err := m3u8.ParsePlaylist(file)
+	playlistInstance, err := m3u8.ParsePlaylist(file)
 	assert.NoError(t, err)
 
-	segmentNode := playlist.Segments()[0]
-	versionNode, _ := playlist.VersionTag()
+	segmentNode := playlistInstance.Segments()[0]
+	versionNode, _ := playlistInstance.VersionTag()
 
 	isSegment := playlist.IsSegment(segmentNode)
 	isNotSegment := playlist.IsSegment(versionNode)

--- a/playlist/validator.go
+++ b/playlist/validator.go
@@ -64,7 +64,7 @@ func IsDuplicatedBreak(adBreak, previousAdBreak *internal.Node) bool {
 	return sameStartDate && sameDuration
 }
 
-// Checks if the given cue out segment belongs to the ad break with the given media sequence
+// Checks if the given cue out node belongs to the ad break with the given media sequence
 func (p *Playlist) IsCueOutFromBreak(breakMediaSequence int, cueOutSegment *internal.Node) bool {
 	nextSegment := p.FindNextSegment(cueOutSegment)
 
@@ -77,7 +77,7 @@ func (p *Playlist) IsCueOutFromBreak(breakMediaSequence int, cueOutSegment *inte
 	return false
 }
 
-// Checks if the given cue in segment belongs to the ad break with the given start date timestamp
+// Checks if the given cue in node belongs to the ad break with the given start date timestamp
 func (p *Playlist) IsCueInFromBreak(breakTimestamp string, cueInSegment *internal.Node) bool {
 	previousSegment := p.FindPreviousSegment(cueInSegment)
 

--- a/playlist/validator.go
+++ b/playlist/validator.go
@@ -2,6 +2,7 @@ package playlist
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -75,14 +76,15 @@ func (p *Playlist) IsCueOutFromBreak(breakMediaSequence int, currentElement *int
 	return false
 }
 
-func (p *Playlist) IsCueInFromBreak(breakMediaSequence int, currentElement *internal.Node) bool {
+func (p *Playlist) IsCueInFromBreak(breakTimestamp string, currentElement *internal.Node) bool {
 	previousSegment := p.FindPreviousSegment(currentElement)
 
 	if previousSegment != nil {
 		adBreakNode, found := p.FindNodeInsideAdBreak(previousSegment)
+		startDate, _ := ValidateStartDate(adBreakNode)
+		realTimestamp := fmt.Sprintf("%d", startDate.Unix())
 		if found {
-			adBreakMediaSequence, _ := ValidateMediaSequence(adBreakNode)
-			return found && adBreakMediaSequence == breakMediaSequence
+			return found && realTimestamp == breakTimestamp
 		}
 	}
 	return false

--- a/playlist/validator.go
+++ b/playlist/validator.go
@@ -65,7 +65,7 @@ func IsDuplicatedBreak(adBreak, previousAdBreak *internal.Node) bool {
 
 func IsSameMediaSequenceFromBreak(breakMediaSequence int, element *internal.Node, manifest Playlist) bool {
 
-	if element != nil && manifest.IsSegment(element) {
+	if element != nil && IsSegment(element) {
 		currentMediaSequence, _ := strconv.Atoi(element.HLSElement.Details["MediaSequence"])
 		if breakMediaSequence == currentMediaSequence {
 			return true
@@ -75,9 +75,13 @@ func IsSameMediaSequenceFromBreak(breakMediaSequence int, element *internal.Node
 }
 
 func IsCueInMediaSequenceFromBreak(breakMediaSequence int, element *internal.Node, manifest Playlist) bool {
-	previous2Element := element.Prev.Prev
-	if previous2Element != nil && manifest.IsSegment(previous2Element) {
-		adBreakNode, found := manifest.FindNodeInsideAdBreak(element)
+	previousElement := element.Prev.Prev
+	if previousElement != nil && previousElement.HLSElement.Name == "Comment" {
+		previousElement = previousElement.Prev
+	}
+
+	if previousElement != nil && IsSegment(previousElement) {
+		adBreakNode, found := manifest.FindNodeInsideAdBreak(previousElement)
 		if found {
 			adBreakMediaSequence, _ := strconv.Atoi(adBreakNode.HLSElement.Details["StartMediaSequence"])
 			if adBreakMediaSequence == breakMediaSequence {

--- a/playlist/validator.go
+++ b/playlist/validator.go
@@ -63,7 +63,7 @@ func IsDuplicatedBreak(adBreak, previousAdBreak *internal.Node) bool {
 	return sameStartDate && sameDuration
 }
 
-func (p *Playlist) IsCueOutMediaSequenceFromBreak(breakMediaSequence int, currentElement *internal.Node) bool {
+func (p *Playlist) IsCueOutFromBreak(breakMediaSequence int, currentElement *internal.Node) bool {
 	nextSegment := p.FindNextSegment(currentElement)
 
 	if nextSegment != nil {

--- a/playlist/validator.go
+++ b/playlist/validator.go
@@ -80,7 +80,7 @@ func (p *Playlist) IsCueInFromBreak(breakMediaSequence int, currentElement *inte
 
 	if previousSegment != nil {
 		node, found := p.FindNodeInsideAdBreak(previousSegment)
-		nodeMediaSequence, _ := strconv.Atoi(node.HLSElement.Details["MediaSequence"])
+		nodeMediaSequence, _ := strconv.Atoi(node.HLSElement.Details["StartMediaSequence"])
 		if found {
 			if nodeMediaSequence == breakMediaSequence {
 				return true

--- a/playlist/validator.go
+++ b/playlist/validator.go
@@ -64,7 +64,6 @@ func IsDuplicatedBreak(adBreak, previousAdBreak *internal.Node) bool {
 }
 
 func IsSameMediaSequenceFromBreak(breakMediaSequence int, element *internal.Node, manifest Playlist) bool {
-
 	if element != nil && IsSegment(element) {
 		currentMediaSequence, _ := strconv.Atoi(element.HLSElement.Details["MediaSequence"])
 		if breakMediaSequence == currentMediaSequence {

--- a/playlist/validator.go
+++ b/playlist/validator.go
@@ -64,8 +64,9 @@ func IsDuplicatedBreak(adBreak, previousAdBreak *internal.Node) bool {
 	return sameStartDate && sameDuration
 }
 
-func (p *Playlist) IsCueOutFromBreak(breakMediaSequence int, currentElement *internal.Node) bool {
-	nextSegment := p.FindNextSegment(currentElement)
+// Checks if the given cue out segment belongs to the ad break with the given media sequence
+func (p *Playlist) IsCueOutFromBreak(breakMediaSequence int, cueOutSegment *internal.Node) bool {
+	nextSegment := p.FindNextSegment(cueOutSegment)
 
 	if nextSegment != nil {
 		currentMediaSequence, _ := strconv.Atoi(nextSegment.HLSElement.Details["MediaSequence"])
@@ -76,14 +77,15 @@ func (p *Playlist) IsCueOutFromBreak(breakMediaSequence int, currentElement *int
 	return false
 }
 
-func (p *Playlist) IsCueInFromBreak(breakTimestamp string, currentElement *internal.Node) bool {
-	previousSegment := p.FindPreviousSegment(currentElement)
+// Checks if the given cue in segment belongs to the ad break with the given start date timestamp
+func (p *Playlist) IsCueInFromBreak(breakTimestamp string, cueInSegment *internal.Node) bool {
+	previousSegment := p.FindPreviousSegment(cueInSegment)
 
 	if previousSegment != nil {
 		adBreakNode, found := p.FindNodeInsideAdBreak(previousSegment)
-		startDate, _ := ValidateStartDate(adBreakNode)
-		adBreakTimeStamp := fmt.Sprintf("%d", startDate.Unix())
 		if found {
+			startDate, _ := ValidateStartDate(adBreakNode)
+			adBreakTimeStamp := fmt.Sprintf("%d", startDate.Unix())
 			return found && adBreakTimeStamp == breakTimestamp
 		}
 	}

--- a/playlist/validator.go
+++ b/playlist/validator.go
@@ -65,8 +65,8 @@ func IsDuplicatedBreak(adBreak, previousAdBreak *internal.Node) bool {
 }
 
 // Checks if the given cue out node belongs to the ad break with the given media sequence
-func (p *Playlist) IsCueOutFromBreak(breakMediaSequence int, cueOutSegment *internal.Node) bool {
-	nextSegment := p.FindNextSegment(cueOutSegment)
+func (p *Playlist) IsCueOutFromBreak(breakMediaSequence int, cueOutNode *internal.Node) bool {
+	nextSegment := p.FindNextSegment(cueOutNode)
 
 	if nextSegment != nil {
 		currentMediaSequence, _ := strconv.Atoi(nextSegment.HLSElement.Details["MediaSequence"])
@@ -78,8 +78,8 @@ func (p *Playlist) IsCueOutFromBreak(breakMediaSequence int, cueOutSegment *inte
 }
 
 // Checks if the given cue in node belongs to the ad break with the given start date timestamp
-func (p *Playlist) IsCueInFromBreak(breakTimestamp string, cueInSegment *internal.Node) bool {
-	previousSegment := p.FindPreviousSegment(cueInSegment)
+func (p *Playlist) IsCueInFromBreak(breakTimestamp string, cueInNode *internal.Node) bool {
+	previousSegment := p.FindPreviousSegment(cueInNode)
 
 	if previousSegment != nil {
 		adBreakNode, found := p.FindNodeInsideAdBreak(previousSegment)

--- a/playlist/validator.go
+++ b/playlist/validator.go
@@ -73,3 +73,17 @@ func IsSameMediaSequenceFromBreak(breakMediaSequence int, element *internal.Node
 	}
 	return false
 }
+
+func IsCueInMediaSequenceFromBreak(breakMediaSequence int, element *internal.Node, manifest Playlist) bool {
+	previous2Element := element.Prev.Prev
+	if previous2Element != nil && manifest.IsSegment(previous2Element) {
+		adBreakNode, found := manifest.FindNodeInsideAdBreak(element)
+		if found {
+			adBreakMediaSequence, _ := strconv.Atoi(adBreakNode.HLSElement.Details["StartMediaSequence"])
+			if adBreakMediaSequence == breakMediaSequence {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/playlist/validator.go
+++ b/playlist/validator.go
@@ -75,7 +75,7 @@ func (p *Playlist) IsCueOutMediaSequenceFromBreak(breakMediaSequence int, curren
 	return false
 }
 
-func (p *Playlist) IsCueInMediaSequenceFromBreak(breakMediaSequence int, currentElement *internal.Node) bool {
+func (p *Playlist) IsCueInFromBreak(breakMediaSequence int, currentElement *internal.Node) bool {
 	previousSegment := p.FindPreviousSegment(currentElement)
 
 	if previousSegment != nil {

--- a/playlist/validator.go
+++ b/playlist/validator.go
@@ -63,9 +63,11 @@ func IsDuplicatedBreak(adBreak, previousAdBreak *internal.Node) bool {
 	return sameStartDate && sameDuration
 }
 
-func IsSameMediaSequenceFromBreak(breakMediaSequence int, element *internal.Node, manifest Playlist) bool {
-	if element != nil && IsSegment(element) {
-		currentMediaSequence, _ := strconv.Atoi(element.HLSElement.Details["MediaSequence"])
+func (p *Playlist) IsCueOutMediaSequenceFromBreak(breakMediaSequence int, currentElement *internal.Node) bool {
+	nextSegment := p.FindNextSegment(currentElement)
+
+	if nextSegment != nil {
+		currentMediaSequence, _ := strconv.Atoi(nextSegment.HLSElement.Details["MediaSequence"])
 		if breakMediaSequence == currentMediaSequence {
 			return true
 		}
@@ -73,17 +75,14 @@ func IsSameMediaSequenceFromBreak(breakMediaSequence int, element *internal.Node
 	return false
 }
 
-func IsCueInMediaSequenceFromBreak(breakMediaSequence int, element *internal.Node, manifest Playlist) bool {
-	previousElement := element.Prev.Prev
-	if previousElement != nil && previousElement.HLSElement.Name == "Comment" {
-		previousElement = previousElement.Prev
-	}
+func (p *Playlist) IsCueInMediaSequenceFromBreak(breakMediaSequence int, currentElement *internal.Node) bool {
+	previousSegment := p.FindPreviousSegment(currentElement)
 
-	if previousElement != nil && IsSegment(previousElement) {
-		adBreakNode, found := manifest.FindNodeInsideAdBreak(previousElement)
+	if previousSegment != nil {
+		node, found := p.FindNodeInsideAdBreak(previousSegment)
+		nodeMediaSequence, _ := strconv.Atoi(node.HLSElement.Details["StartMediaSequence"])
 		if found {
-			adBreakMediaSequence, _ := strconv.Atoi(adBreakNode.HLSElement.Details["StartMediaSequence"])
-			if adBreakMediaSequence == breakMediaSequence {
+			if nodeMediaSequence == breakMediaSequence {
 				return true
 			}
 		}

--- a/playlist/validator.go
+++ b/playlist/validator.go
@@ -64,29 +64,25 @@ func IsDuplicatedBreak(adBreak, previousAdBreak *internal.Node) bool {
 }
 
 func (p *Playlist) IsCueOutFromBreak(breakMediaSequence int, currentElement *internal.Node) bool {
-	if currentElement.HLSElement.Name == "cue-out" {
-		nextSegment := p.FindNextSegment(currentElement)
+	nextSegment := p.FindNextSegment(currentElement)
 
-		if nextSegment != nil {
-			currentMediaSequence, _ := strconv.Atoi(nextSegment.HLSElement.Details["MediaSequence"])
-			if breakMediaSequence == currentMediaSequence {
-				return true
-			}
+	if nextSegment != nil {
+		currentMediaSequence, _ := strconv.Atoi(nextSegment.HLSElement.Details["MediaSequence"])
+		if breakMediaSequence == currentMediaSequence {
+			return true
 		}
 	}
 	return false
 }
 
 func (p *Playlist) IsCueInFromBreak(breakMediaSequence int, currentElement *internal.Node) bool {
-	if currentElement.HLSElement.Name == "cue-in" {
-		previousSegment := p.FindPreviousSegment(currentElement)
+	previousSegment := p.FindPreviousSegment(currentElement)
 
-		if previousSegment != nil {
-			adBreakNode, found := p.FindNodeInsideAdBreak(previousSegment)
-			if found {
-				adBreakMediaSequence, _ := ValidateMediaSequence(adBreakNode)
-				return found && adBreakMediaSequence == breakMediaSequence
-			}
+	if previousSegment != nil {
+		adBreakNode, found := p.FindNodeInsideAdBreak(previousSegment)
+		if found {
+			adBreakMediaSequence, _ := ValidateMediaSequence(adBreakNode)
+			return found && adBreakMediaSequence == breakMediaSequence
 		}
 	}
 	return false

--- a/playlist/validator.go
+++ b/playlist/validator.go
@@ -79,13 +79,9 @@ func (p *Playlist) IsCueInFromBreak(breakMediaSequence int, currentElement *inte
 	previousSegment := p.FindPreviousSegment(currentElement)
 
 	if previousSegment != nil {
-		node, found := p.FindNodeInsideAdBreak(previousSegment)
-		if found {
-			nodeMediaSequence, _ := strconv.Atoi(node.HLSElement.Details["StartMediaSequence"])
-			if nodeMediaSequence == breakMediaSequence {
-				return true
-			}
-		}
+		adBreakNode, found := p.FindNodeInsideAdBreak(previousSegment)
+		adBreakMediaSequence, _ := strconv.Atoi(adBreakNode.HLSElement.Details["StartMediaSequence"])
+		return found && adBreakMediaSequence == breakMediaSequence
 	}
 	return false
 }

--- a/playlist/validator.go
+++ b/playlist/validator.go
@@ -80,8 +80,10 @@ func (p *Playlist) IsCueInFromBreak(breakMediaSequence int, currentElement *inte
 
 	if previousSegment != nil {
 		adBreakNode, found := p.FindNodeInsideAdBreak(previousSegment)
-		adBreakMediaSequence, _ := strconv.Atoi(adBreakNode.HLSElement.Details["StartMediaSequence"])
-		return found && adBreakMediaSequence == breakMediaSequence
+		if found {
+			adBreakMediaSequence, _ := ValidateMediaSequence(adBreakNode)
+			return found && adBreakMediaSequence == breakMediaSequence
+		}
 	}
 	return false
 }

--- a/playlist/validator.go
+++ b/playlist/validator.go
@@ -80,8 +80,8 @@ func (p *Playlist) IsCueInFromBreak(breakMediaSequence int, currentElement *inte
 
 	if previousSegment != nil {
 		node, found := p.FindNodeInsideAdBreak(previousSegment)
-		nodeMediaSequence, _ := strconv.Atoi(node.HLSElement.Details["StartMediaSequence"])
 		if found {
+			nodeMediaSequence, _ := strconv.Atoi(node.HLSElement.Details["StartMediaSequence"])
 			if nodeMediaSequence == breakMediaSequence {
 				return true
 			}

--- a/playlist/validator.go
+++ b/playlist/validator.go
@@ -62,3 +62,14 @@ func IsDuplicatedBreak(adBreak, previousAdBreak *internal.Node) bool {
 
 	return sameStartDate && sameDuration
 }
+
+func isSameMediaSequenceFromBreak(breakMediaSequence int, element *internal.Node, manifest Playlist) bool {
+
+	if element != nil && manifest.IsSegment(element) {
+		currentMediaSequence, _ := strconv.Atoi(element.HLSElement.Details["MediaSequence"])
+		if breakMediaSequence == currentMediaSequence {
+			return true
+		}
+	}
+	return false
+}

--- a/playlist/validator.go
+++ b/playlist/validator.go
@@ -82,9 +82,9 @@ func (p *Playlist) IsCueInFromBreak(breakTimestamp string, currentElement *inter
 	if previousSegment != nil {
 		adBreakNode, found := p.FindNodeInsideAdBreak(previousSegment)
 		startDate, _ := ValidateStartDate(adBreakNode)
-		realTimestamp := fmt.Sprintf("%d", startDate.Unix())
+		adBreakTimeStamp := fmt.Sprintf("%d", startDate.Unix())
 		if found {
-			return found && realTimestamp == breakTimestamp
+			return found && adBreakTimeStamp == breakTimestamp
 		}
 	}
 	return false

--- a/playlist/validator.go
+++ b/playlist/validator.go
@@ -80,7 +80,7 @@ func (p *Playlist) IsCueInFromBreak(breakMediaSequence int, currentElement *inte
 
 	if previousSegment != nil {
 		node, found := p.FindNodeInsideAdBreak(previousSegment)
-		nodeMediaSequence, _ := strconv.Atoi(node.HLSElement.Details["StartMediaSequence"])
+		nodeMediaSequence, _ := strconv.Atoi(node.HLSElement.Details["MediaSequence"])
 		if found {
 			if nodeMediaSequence == breakMediaSequence {
 				return true

--- a/playlist/validator.go
+++ b/playlist/validator.go
@@ -63,7 +63,7 @@ func IsDuplicatedBreak(adBreak, previousAdBreak *internal.Node) bool {
 	return sameStartDate && sameDuration
 }
 
-func isSameMediaSequenceFromBreak(breakMediaSequence int, element *internal.Node, manifest Playlist) bool {
+func IsSameMediaSequenceFromBreak(breakMediaSequence int, element *internal.Node, manifest Playlist) bool {
 
 	if element != nil && manifest.IsSegment(element) {
 		currentMediaSequence, _ := strconv.Atoi(element.HLSElement.Details["MediaSequence"])

--- a/playlist/validator.go
+++ b/playlist/validator.go
@@ -64,25 +64,29 @@ func IsDuplicatedBreak(adBreak, previousAdBreak *internal.Node) bool {
 }
 
 func (p *Playlist) IsCueOutFromBreak(breakMediaSequence int, currentElement *internal.Node) bool {
-	nextSegment := p.FindNextSegment(currentElement)
+	if currentElement.HLSElement.Name == "cue-out" {
+		nextSegment := p.FindNextSegment(currentElement)
 
-	if nextSegment != nil {
-		currentMediaSequence, _ := strconv.Atoi(nextSegment.HLSElement.Details["MediaSequence"])
-		if breakMediaSequence == currentMediaSequence {
-			return true
+		if nextSegment != nil {
+			currentMediaSequence, _ := strconv.Atoi(nextSegment.HLSElement.Details["MediaSequence"])
+			if breakMediaSequence == currentMediaSequence {
+				return true
+			}
 		}
 	}
 	return false
 }
 
 func (p *Playlist) IsCueInFromBreak(breakMediaSequence int, currentElement *internal.Node) bool {
-	previousSegment := p.FindPreviousSegment(currentElement)
+	if currentElement.HLSElement.Name == "cue-in" {
+		previousSegment := p.FindPreviousSegment(currentElement)
 
-	if previousSegment != nil {
-		adBreakNode, found := p.FindNodeInsideAdBreak(previousSegment)
-		if found {
-			adBreakMediaSequence, _ := ValidateMediaSequence(adBreakNode)
-			return found && adBreakMediaSequence == breakMediaSequence
+		if previousSegment != nil {
+			adBreakNode, found := p.FindNodeInsideAdBreak(previousSegment)
+			if found {
+				adBreakMediaSequence, _ := ValidateMediaSequence(adBreakNode)
+				return found && adBreakMediaSequence == breakMediaSequence
+			}
 		}
 	}
 	return false

--- a/playlist/validator_test.go
+++ b/playlist/validator_test.go
@@ -118,3 +118,16 @@ func TestIsDuplicatedBreak(t *testing.T) {
 	isDuplicate := playlist.IsDuplicatedBreak(lastBreak, previousBreak)
 	assert.True(t, isDuplicate)
 }
+
+func TestIsSameMediaSequenceFromBreak(t *testing.T) {
+	file, _ := os.Open("./../mocks/media/media.m3u8")
+	pl, err := m3u8.ParsePlaylist(file)
+	assert.NoError(t, err)
+
+	segments := pl.Segments()
+	segmentElement := segments[6]
+
+	breakMediaSequence := 364042175
+	result := playlist.IsSameMediaSequenceFromBreak(breakMediaSequence, segmentElement, *pl)
+	assert.True(t, result)
+}

--- a/playlist/validator_test.go
+++ b/playlist/validator_test.go
@@ -131,14 +131,14 @@ func TestIsCueOutMediaSequenceFromBreak(t *testing.T) {
 	assert.True(t, result)
 }
 
-func TestIsCueInMediaSequenceFromBreak(t *testing.T) {
+func TestIsCueInFromBreak(t *testing.T) {
 	file, _ := os.Open("./../mocks/media/media.m3u8")
 	pl, err := m3u8.ParsePlaylist(file)
 	assert.NoError(t, err)
 	cueInNode, _ := pl.Find("CueIn")
 	breakMediaSequence := 364042175
 
-	result := pl.IsCueInMediaSequenceFromBreak(breakMediaSequence, cueInNode)
+	result := pl.IsCueInFromBreak(breakMediaSequence, cueInNode)
 	assert.True(t, result)
 
 }

--- a/playlist/validator_test.go
+++ b/playlist/validator_test.go
@@ -119,16 +119,15 @@ func TestIsDuplicatedBreak(t *testing.T) {
 	assert.True(t, isDuplicate)
 }
 
-func TestIsSameMediaSequenceFromBreak(t *testing.T) {
+func TestIsCueOutMediaSequenceFromBreak(t *testing.T) {
 	file, _ := os.Open("./../mocks/media/media.m3u8")
 	pl, err := m3u8.ParsePlaylist(file)
 	assert.NoError(t, err)
 
-	segments := pl.Segments()
-	segmentElement := segments[6]
+	cueOutNode, _ := pl.Find("CueOut")
 
 	breakMediaSequence := 364042175
-	result := playlist.IsSameMediaSequenceFromBreak(breakMediaSequence, segmentElement, *pl)
+	result := pl.IsCueOutMediaSequenceFromBreak(breakMediaSequence, cueOutNode)
 	assert.True(t, result)
 }
 
@@ -139,7 +138,7 @@ func TestIsCueInMediaSequenceFromBreak(t *testing.T) {
 	cueInNode, _ := pl.Find("CueIn")
 	breakMediaSequence := 364042175
 
-	result := playlist.IsCueInMediaSequenceFromBreak(breakMediaSequence, cueInNode, *pl)
+	result := pl.IsCueInMediaSequenceFromBreak(breakMediaSequence, cueInNode)
 	assert.True(t, result)
 
 }

--- a/playlist/validator_test.go
+++ b/playlist/validator_test.go
@@ -119,7 +119,7 @@ func TestIsDuplicatedBreak(t *testing.T) {
 	assert.True(t, isDuplicate)
 }
 
-func TestIsCueOutMediaSequenceFromBreak(t *testing.T) {
+func TestIsCueOutFromBreak(t *testing.T) {
 	file, _ := os.Open("./../mocks/media/media.m3u8")
 	pl, err := m3u8.ParsePlaylist(file)
 	assert.NoError(t, err)
@@ -127,7 +127,7 @@ func TestIsCueOutMediaSequenceFromBreak(t *testing.T) {
 	cueOutNode, _ := pl.Find("CueOut")
 
 	breakMediaSequence := 364042175
-	result := pl.IsCueOutMediaSequenceFromBreak(breakMediaSequence, cueOutNode)
+	result := pl.IsCueOutFromBreak(breakMediaSequence, cueOutNode)
 	assert.True(t, result)
 }
 

--- a/playlist/validator_test.go
+++ b/playlist/validator_test.go
@@ -131,3 +131,15 @@ func TestIsSameMediaSequenceFromBreak(t *testing.T) {
 	result := playlist.IsSameMediaSequenceFromBreak(breakMediaSequence, segmentElement, *pl)
 	assert.True(t, result)
 }
+
+func TestIsCueInMediaSequenceFromBreak(t *testing.T) {
+	file, _ := os.Open("./../mocks/media/media.m3u8")
+	pl, err := m3u8.ParsePlaylist(file)
+	assert.NoError(t, err)
+	cueInNode, _ := pl.Find("CueIn")
+	breakMediaSequence := 364042175
+
+	result := playlist.IsCueInMediaSequenceFromBreak(breakMediaSequence, cueInNode, *pl)
+	assert.True(t, result)
+
+}

--- a/playlist/validator_test.go
+++ b/playlist/validator_test.go
@@ -136,9 +136,9 @@ func TestIsCueInFromBreak(t *testing.T) {
 	pl, err := m3u8.ParsePlaylist(file)
 	assert.NoError(t, err)
 	cueInNode, _ := pl.Find("CueIn")
-	breakMediaSequence := 364042175
+	breakTimestamp := "1747402436"
 
-	result := pl.IsCueInFromBreak(breakMediaSequence, cueInNode)
+	result := pl.IsCueInFromBreak(breakTimestamp, cueInNode)
 	assert.True(t, result)
 
 }


### PR DESCRIPTION
## What type of PR is this?

<!-- Select the type of Pull Request below. You may select more than one category if applicable. -->
<!-- If this PR is a draft, remember to create it as such. -->

- [ ] 🧹 Refactor: Improves codebase readability and perfomance without adding a new functionality.
- [X] 💎 Feature: Introduces a new functionality.
- [ ] 🐛 Bug Fix: Patches a bug in the codebase.
- [ ] 📖 Documentation: Adds or updates documentation files.
- [ ] 🧪 CI: Updates CI/CD configuration.
- [ ] 🔙 Revert: Rollbacks previous changes.

## Description
Create method to check if given node have the same media sequence as break.
Create method to check if given cue-in node have the same media sequence as break
Those methods are going to be used to skip discontinuity sequence in dai pause ads cases.

## Related Tickets & Documents

<!-- Describe any relevant related tickets or issues here. When necessary, add further documentation to elaborate on the issue at hand. -->

- **Related Issue:** N/A
- **Closes:** N/A

## QA Instructions & Examples


## Added/Updated Tests?
- [X] Yes
- [ ] No, and this is why: _N/A_
- [ ] I need help with writing tests