### PR TITLE
Improve memory usage

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -70,21 +70,7 @@ func extractPrefix(line string) string {
 	return tags.CommentLineTag
 }
 
-// isHLSTag checks if a line is an HLS tag by examining its prefix.
-// Tags must start with #ext (case-insensitive) or #usp (case-insensitive).
-// This function converts the prefix to lowercase internally for comparison.
+// isRegularHLSTag checks if a line is an HLS tag by examining its prefix.
 func isRegularHLSTag(line string) bool {
-	if len(line) < 4 {
-		return false
-	}
-
-	prefix := line[:4]
-	lowerPrefix := strings.ToLower(prefix)
-
-	// Check for #ext or #usp (case-insensitive)
-	if lowerPrefix == "#ext" || lowerPrefix == "#usp" {
-		return true
-	}
-
-	return false
+	return strings.HasPrefix(line, "#EXT") || strings.HasPrefix(line, "#ext") || strings.HasPrefix(line, "#USP")
 }

--- a/decode.go
+++ b/decode.go
@@ -51,12 +51,7 @@ func ParsePlaylist(src Source) (*pl.Playlist, error) {
 // Lines that start with the character '#' are either comments or tags.
 // Tags begin with #EXT or #USP. All other lines that begin with '#' are comments and SHOULD be ignored.
 func extractPrefix(line string) string {
-	if line == "" {
-		return ""
-	}
-
-	// Check if line starts with '#'
-	if line[0] != '#' {
+	if line == "" || line[0] != '#' {
 		// Not a tag or comment, return as is (URI or data line)
 		return line
 	}

--- a/decode.go
+++ b/decode.go
@@ -52,27 +52,26 @@ func ParsePlaylist(src Source) (*pl.Playlist, error) {
 // Lines that start with the character '#' are either comments or tags.
 // Tags begin with #EXT.  They are case sensitive.  All other lines that begin with '#' are comments and SHOULD be ignored.
 func extractPrefix(line string) string {
-	// check for blank lines
 	if line == "" {
 		return ""
 	}
 
-	// check for comments
-	isComment, err := tags.CommentLineRegex.MatchString(line)
-	if err != nil {
-		log.Error().Str("service", "go-m3u8/decode.go").Err(err).Msgf("failed to parse line: %s", line)
-		return ""
+	// check for tags: lines starting with #EXT, #ext ou #USP (case sensitive)
+	if strings.HasPrefix(line, "#EXT") || strings.HasPrefix(line, "#ext") || strings.HasPrefix(line, "#USP") {
+		// it's a tag, extract prefix as before
+		for i, r := range line {
+			if r == ':' || unicode.IsSpace(r) {
+				return line[:i]
+			}
+		}
+		return line
 	}
 
-	if isComment {
+	// if starts with '#' but is not a tag, it's a comment
+	if strings.HasPrefix(line, "#") {
 		return tags.CommentLineTag
 	}
 
-	// check for tags and uri
-	for i, r := range line {
-		if r == ':' || unicode.IsSpace(r) {
-			return line[:i]
-		}
-	}
+	// otherwise, return as is (URI or data line)
 	return line
 }

--- a/decode.go
+++ b/decode.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"unicode"
 
 	pl "github.com/globocom/go-m3u8/playlist"
 	"github.com/globocom/go-m3u8/tags"
@@ -56,24 +55,24 @@ func extractPrefix(line string) string {
 		return ""
 	}
 
-	// Check if line is a tag
+	// Check if line starts with '#'
+	if line[0] != '#' {
+		// Not a tag or comment, return as is (URI or data line)
+		return line
+	}
+
+	// Check if it's an HLS tag (#ext or #usp)
 	if isRegularHLSTag(line) {
-		// it's a tag, extract prefix until ':' or whitespace
-		for i, r := range line {
-			if r == ':' || unicode.IsSpace(r) {
-				return line[:i]
-			}
+		// Extract prefix until ':' or whitespace
+		idx := strings.IndexAny(line, ": \t\n\r")
+		if idx != -1 {
+			return line[:idx]
 		}
 		return line
 	}
 
 	// if starts with '#' but is not a tag, it's a comment
-	if strings.HasPrefix(line, "#") {
-		return tags.CommentLineTag
-	}
-
-	// otherwise, return as is (URI or data line)
-	return line
+	return tags.CommentLineTag
 }
 
 // isHLSTag checks if a line is an HLS tag by examining its prefix.

--- a/decode.go
+++ b/decode.go
@@ -50,15 +50,15 @@ func ParsePlaylist(src Source) (*pl.Playlist, error) {
 }
 
 // Lines that start with the character '#' are either comments or tags.
-// Tags begin with #EXT.  They are case sensitive.  All other lines that begin with '#' are comments and SHOULD be ignored.
+// Tags begin with #EXT or #USP. All other lines that begin with '#' are comments and SHOULD be ignored.
 func extractPrefix(line string) string {
 	if line == "" {
 		return ""
 	}
 
-	// check for tags: lines starting with #EXT, #ext ou #USP (case sensitive)
-	if strings.HasPrefix(line, "#EXT") || strings.HasPrefix(line, "#ext") || strings.HasPrefix(line, "#USP") {
-		// it's a tag, extract prefix as before
+	// Check if line is a tag
+	if isRegularHLSTag(line) {
+		// it's a tag, extract prefix until ':' or whitespace
 		for i, r := range line {
 			if r == ':' || unicode.IsSpace(r) {
 				return line[:i]
@@ -74,4 +74,23 @@ func extractPrefix(line string) string {
 
 	// otherwise, return as is (URI or data line)
 	return line
+}
+
+// isHLSTag checks if a line is an HLS tag by examining its prefix.
+// Tags must start with #ext (case-insensitive) or #usp (case-insensitive).
+// This function converts the prefix to lowercase internally for comparison.
+func isRegularHLSTag(line string) bool {
+	if len(line) < 4 {
+		return false
+	}
+
+	prefix := line[:4]
+	lowerPrefix := strings.ToLower(prefix)
+
+	// Check for #ext or #usp (case-insensitive)
+	if lowerPrefix == "#ext" || lowerPrefix == "#usp" {
+		return true
+	}
+
+	return false
 }

--- a/playlist/filters.go
+++ b/playlist/filters.go
@@ -8,8 +8,8 @@ import (
 // Removes all variant streams (#EXT-X-STREAM-INF) from the playlist that exceed the given maxHeight.
 func (p *Playlist) FilterByMaxHeight(maxHeight int) {
 	nodes := p.Variants()
-	for _, node := range nodes {
-		resolution := node.HLSElement.Attrs["RESOLUTION"]
+	for i := range nodes {
+		resolution := nodes[i].HLSElement.Attrs["RESOLUTION"]
 		if resolution == "" {
 			continue
 		}
@@ -23,7 +23,7 @@ func (p *Playlist) FilterByMaxHeight(maxHeight int) {
 			continue
 		}
 		if height > maxHeight {
-			p.Remove(node)
+			p.Remove(nodes[i])
 		}
 	}
 }

--- a/playlist/helpers.go
+++ b/playlist/helpers.go
@@ -95,7 +95,7 @@ func HandleMultiLineHLSElements(line string, p *Playlist) error {
 					"Title":    p.CurrentSegment.Title,
 				},
 				Details: map[string]string{
-					"MediaSequence":   fmt.Sprintf("%d", p.CurrentSegment.MediaSequence),
+					"MediaSequence":   strconv.Itoa(p.CurrentSegment.MediaSequence),
 					"ProgramDateTime": p.CurrentSegment.ProgramDateTime.Format(time.RFC3339Nano),
 				},
 			},

--- a/playlist/helpers.go
+++ b/playlist/helpers.go
@@ -160,13 +160,20 @@ func EncodeTagWithAttributes(builder *strings.Builder, tag string, attrs map[str
 		return err
 	}
 
-	formattedAttrs := make([]string, 0, len(attrs))
+	builder.WriteString(tag)
+	builder.WriteByte(':')
+
 	processed := make(map[string]bool)
+	first := true
 
 	for _, key := range order {
 		if value, exists := attrs[key]; exists && value != "" {
-			formattedAttrs = append(formattedAttrs, FormatAttribute(key, value, shouldQuote))
+			if !first {
+				builder.WriteByte(',')
+			}
+			writeAttribute(builder, key, value, shouldQuote)
 			processed[key] = true
+			first = false
 		}
 	}
 
@@ -178,13 +185,15 @@ func EncodeTagWithAttributes(builder *strings.Builder, tag string, attrs map[str
 	}
 	sort.Strings(unorderedKeys)
 	for _, key := range unorderedKeys {
-		formattedAttrs = append(formattedAttrs, FormatAttribute(key, attrs[key], shouldQuote))
+		if !first {
+			builder.WriteByte(',')
+		}
+		writeAttribute(builder, key, attrs[key], shouldQuote)
+		first = false
 	}
 
-	attributes := fmt.Sprintf("%s:%s\n", tag, strings.Join(formattedAttrs, ","))
-
-	_, err := builder.WriteString(attributes)
-	return err
+	builder.WriteByte('\n')
+	return nil
 }
 
 // Encodes a tag without attributes into a string.
@@ -195,6 +204,31 @@ func EncodeSimpleTag(node *internal.Node, builder *strings.Builder, tag, attrKey
 		return err
 	}
 	return fmt.Errorf("attribute %s not found for tag %s", attrKey, tag)
+}
+
+// Writes a key-value attribute directly to the builder, optionally quoting the value.
+func writeAttribute(builder *strings.Builder, key, value string, shouldQuote map[string]bool) {
+	builder.WriteString(key)
+	builder.WriteByte('=')
+
+	shouldQuoteValue, exists := shouldQuote[key]
+	if !exists {
+		shouldQuoteValue = true // default to quoting if not specified
+	}
+
+	if shouldQuoteValue {
+		builder.WriteByte('"')
+		// Escape quotes in the value
+		for i := 0; i < len(value); i++ {
+			if value[i] == '"' {
+				builder.WriteByte('\\')
+			}
+			builder.WriteByte(value[i])
+		}
+		builder.WriteByte('"')
+	} else {
+		builder.WriteString(value)
+	}
 }
 
 // Formats a key-value tag attribute into a string, optionally quoting the value based on the shouldQuote map.

--- a/playlist/helpers.go
+++ b/playlist/helpers.go
@@ -166,13 +166,13 @@ func EncodeTagWithAttributes(builder *strings.Builder, tag string, attrs map[str
 	processed := make(map[string]bool)
 	first := true
 
-	for _, key := range order {
-		if value, exists := attrs[key]; exists && value != "" {
+	for i := range order {
+		if value, exists := attrs[order[i]]; exists && value != "" {
 			if !first {
 				builder.WriteByte(',')
 			}
-			writeAttribute(builder, key, value, shouldQuote)
-			processed[key] = true
+			writeAttribute(builder, order[i], value, shouldQuote)
+			processed[order[i]] = true
 			first = false
 		}
 	}
@@ -184,11 +184,11 @@ func EncodeTagWithAttributes(builder *strings.Builder, tag string, attrs map[str
 		}
 	}
 	sort.Strings(unorderedKeys)
-	for _, key := range unorderedKeys {
+	for i := range unorderedKeys {
 		if !first {
 			builder.WriteByte(',')
 		}
-		writeAttribute(builder, key, attrs[key], shouldQuote)
+		writeAttribute(builder, unorderedKeys[i], attrs[unorderedKeys[i]], shouldQuote)
 		first = false
 	}
 

--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -149,9 +149,9 @@ func (p *Playlist) CueInEvents() []*internal.Node {
 func (p *Playlist) Breaks() []*internal.Node {
 	result := make([]*internal.Node, 0)
 	nodes := p.FindAll("DateRange")
-	for _, node := range nodes {
-		if node.HLSElement.Attrs["SCTE35-OUT"] != "" {
-			result = append(result, node)
+	for i := range nodes {
+		if nodes[i].HLSElement.Attrs["SCTE35-OUT"] != "" {
+			result = append(result, nodes[i])
 		}
 	}
 	return result
@@ -161,9 +161,9 @@ func (p *Playlist) Breaks() []*internal.Node {
 func (p *Playlist) SCTE35InTags() []*internal.Node {
 	result := make([]*internal.Node, 0)
 	nodes := p.FindAll("DateRange")
-	for _, node := range nodes {
-		if node.HLSElement.Attrs["SCTE35-IN"] != "" {
-			result = append(result, node)
+	for i := range nodes {
+		if nodes[i].HLSElement.Attrs["SCTE35-IN"] != "" {
+			result = append(result, nodes[i])
 		}
 	}
 	return result
@@ -174,9 +174,9 @@ func (p *Playlist) SCTE35InTags() []*internal.Node {
 //	Example: "# variants", "# AUDIO groups", etc
 func (p *Playlist) Comment(matchString string) *internal.Node {
 	nodes := p.FindAll("Comment")
-	for _, node := range nodes {
-		if strings.Contains(node.HLSElement.Attrs["Comment"], matchString) {
-			return node
+	for i := range nodes {
+		if strings.Contains(nodes[i].HLSElement.Attrs["Comment"], matchString) {
+			return nodes[i]
 		}
 	}
 	return nil
@@ -291,18 +291,18 @@ func (p *Playlist) removeInvalidBreakTags(adBreak *internal.Node) {
 	}
 
 	cueIns := p.CueInEvents()
-	for _, cueIn := range cueIns {
-		adBreakCueIn, found := p.FindNodeInsideAdBreak(cueIn)
+	for i := range cueIns {
+		adBreakCueIn, found := p.FindNodeInsideAdBreak(cueIns[i])
 		if found && adBreakCueIn == adBreak {
-			if cueIn.Prev != nil && cueIn.Prev.HLSElement.Name == "Comment" && cueIn.Prev.HLSElement.Attrs["Comment"] == "## Auto Return Mode" {
-				p.Remove(cueIn.Prev)
+			if cueIns[i].Prev != nil && cueIns[i].Prev.HLSElement.Name == "Comment" && cueIns[i].Prev.HLSElement.Attrs["Comment"] == "## Auto Return Mode" {
+				p.Remove(cueIns[i].Prev)
 			}
 
-			if cueIn.Next != nil && cueIn.Next.HLSElement.Name == "ProgramDateTime" {
-				p.Remove(cueIn.Next)
+			if cueIns[i].Next != nil && cueIns[i].Next.HLSElement.Name == "ProgramDateTime" {
+				p.Remove(cueIns[i].Next)
 			}
 
-			p.Remove(cueIn)
+			p.Remove(cueIns[i])
 		}
 	}
 
@@ -319,14 +319,14 @@ func (p *Playlist) removeDuplicateBreakTags(adBreak *internal.Node) {
 	}
 
 	cueIns := p.CueInEvents()
-	for _, cueIn := range cueIns {
-		adBreakCueIn, found := p.FindNodeInsideAdBreak(cueIn)
-		if cueIn.Prev != nil && cueIn.Prev.HLSElement.Name == "Comment" && cueIn.Prev.HLSElement.Attrs["Comment"] == "## Auto Return Mode" {
-			p.Remove(cueIn.Prev)
+	for i := range cueIns {
+		adBreakCueIn, found := p.FindNodeInsideAdBreak(cueIns[i])
+		if cueIns[i].Prev != nil && cueIns[i].Prev.HLSElement.Name == "Comment" && cueIns[i].Prev.HLSElement.Attrs["Comment"] == "## Auto Return Mode" {
+			p.Remove(cueIns[i].Prev)
 		}
 
 		if found && adBreakCueIn == adBreak {
-			p.Remove(cueIn)
+			p.Remove(cueIns[i])
 			break
 		}
 	}

--- a/tags/exclusive.go
+++ b/tags/exclusive.go
@@ -32,6 +32,14 @@ var (
 	IndependentSegmentsTag = "#EXT-X-INDEPENDENT-SEGMENTS"
 	VariableDefineTag      = "#EXT-X-DEFINE"
 	StartTag               = "#EXT-X-START" //todo: has attributes
+
+	variableDefineOrderAttr       = []string{"NAME", "VALUE", "IMPORT", "QUERYPARAM"}
+	variableDefineShouldQuoteAttr = map[string]bool{
+		"NAME":       true,
+		"VALUE":      true,
+		"IMPORT":     true,
+		"QUERYPARAM": true,
+	}
 )
 
 type (
@@ -83,12 +91,5 @@ func (e IndependentSegmentsEncoder) Encode(node *internal.Node, builder *strings
 }
 
 func (e VariableDefineEncoder) Encode(node *internal.Node, builder *strings.Builder) error {
-	orderAttr := []string{"NAME", "VALUE", "IMPORT", "QUERYPARAM"}
-	shouldQuoteAttr := map[string]bool{
-		"NAME":       true,
-		"VALUE":      true,
-		"IMPORT":     true,
-		"QUERYPARAM": true,
-	}
-	return pl.EncodeTagWithAttributes(builder, VariableDefineTag, node.HLSElement.Attrs, orderAttr, shouldQuoteAttr)
+	return pl.EncodeTagWithAttributes(builder, VariableDefineTag, node.HLSElement.Attrs, variableDefineOrderAttr, variableDefineShouldQuoteAttr)
 }

--- a/tags/media_metadata.go
+++ b/tags/media_metadata.go
@@ -9,6 +9,7 @@ package tags
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -83,7 +84,7 @@ func (e DateRangeEncoder) Encode(node *internal.Node, builder *strings.Builder) 
 //   - The Break's media sequence will be the media sequence of the first segment inside the break (or zero if Break is incomplete).
 //   - The Break's status will be: "complete" or incomplete ("leavingDVRLimit" or "segmentsNotReady").
 func getAdBreakDetails(playlist *pl.Playlist, dateRangeNode *internal.Node) (value, status string) {
-	currentMediaSequence := fmt.Sprintf("%d", playlist.MediaSequence+playlist.SegmentsCounter)
+	currentMediaSequence := strconv.Itoa(playlist.MediaSequence + playlist.SegmentsCounter)
 	breakStartDate, _ := time.Parse(time.RFC3339Nano, dateRangeNode.HLSElement.Attrs["START-DATE"])
 
 	// when ad break segments are leaving DVR, we lose the break's first segment's media sequence

--- a/tags/media_metadata.go
+++ b/tags/media_metadata.go
@@ -31,6 +31,20 @@ var (
 	SkipTag            = "#EXT-X-SKIP"             //todo: has attributes
 	PreLoadHintTag     = "#EXT-X-PRELOAD-HINT"     //todo: has attributes
 	RenditionReportTag = "#EXT-X-RENDITION-REPORT" //todo: has attributes
+
+	// Attribute X-<client-attribute> is a client-specific attribute and new ones must be added manually below (e.g., X-ASSET-URI)
+	dateRangeOrderAttr       = []string{"ID", "CLASS", "START-DATE", "END-DATE", "DURATION", "PLANNED-DURATION", "X-ASSET-URI", "SCTE35-OUT", "SCTE35-IN"}
+	dateRangeShouldQuoteAttr = map[string]bool{
+		"ID":               true,
+		"CLASS":            true,
+		"START-DATE":       true,
+		"END-DATE":         true,
+		"DURATION":         false,
+		"PLANNED-DURATION": false,
+		"X-ASSET-URI":      true,
+		"SCTE35-OUT":       false,
+		"SCTE35-IN":        false,
+	}
 )
 
 type DateRangeParser struct{}
@@ -64,20 +78,7 @@ func (p DateRangeParser) Parse(tag string, playlist *pl.Playlist) error {
 }
 
 func (e DateRangeEncoder) Encode(node *internal.Node, builder *strings.Builder) error {
-	// Attribute X-<client-attribute> is a client-specific attribute and new ones must be added manually below (e.g., X-ASSET-URI)
-	orderAttr := []string{"ID", "CLASS", "START-DATE", "END-DATE", "DURATION", "PLANNED-DURATION", "X-ASSET-URI", "SCTE35-OUT", "SCTE35-IN"}
-	shouldQuoteAttr := map[string]bool{
-		"ID":               true,
-		"CLASS":            true,
-		"START-DATE":       true,
-		"END-DATE":         true,
-		"DURATION":         false,
-		"PLANNED-DURATION": false,
-		"X-ASSET-URI":      true,
-		"SCTE35-OUT":       false,
-		"SCTE35-IN":        false,
-	}
-	return pl.EncodeTagWithAttributes(builder, DateRangeTag, node.HLSElement.Attrs, orderAttr, shouldQuoteAttr)
+	return pl.EncodeTagWithAttributes(builder, DateRangeTag, node.HLSElement.Attrs, dateRangeOrderAttr, dateRangeShouldQuoteAttr)
 }
 
 // Returns the Ad Break's media sequence (string) and status (string).

--- a/tags/media_segment.go
+++ b/tags/media_segment.go
@@ -37,6 +37,21 @@ var (
 	ByteRangeTag       = "#EXT-X-BYTERANGE" // todo: has attributes
 	GapTag             = "#EXT-X-GAP"
 	PartTag            = "#EXT-X-PART" // todo: has attributes
+
+	mapOrderAttr       = []string{"URI", "BYTERANGE"}
+	mapShouldQuoteAttr = map[string]bool{
+		"URI":       true,
+		"BYTERANGE": true,
+	}
+
+	keyOrderAttr       = []string{"METHOD", "URI", "IV", "KEYFORMAT", "KEYFORMATVERSIONS"}
+	keyShouldQuoteAttr = map[string]bool{
+		"METHOD":            false,
+		"URI":               true,
+		"IV":                false,
+		"KEYFORMAT":         true,
+		"KEYFORMATVERSIONS": true,
+	}
 )
 
 type (
@@ -214,24 +229,11 @@ func (e ProgramDateTimeEncoder) Encode(node *internal.Node, builder *strings.Bui
 }
 
 func (e KeyEncoder) Encode(node *internal.Node, builder *strings.Builder) error {
-	orderAttr := []string{"METHOD", "URI", "IV", "KEYFORMAT", "KEYFORMATVERSIONS"}
-	shouldQuoteAttr := map[string]bool{
-		"METHOD":            false,
-		"URI":               true,
-		"IV":                false,
-		"KEYFORMAT":         true,
-		"KEYFORMATVERSIONS": true,
-	}
-	return pl.EncodeTagWithAttributes(builder, KeyTag, node.HLSElement.Attrs, orderAttr, shouldQuoteAttr)
+	return pl.EncodeTagWithAttributes(builder, KeyTag, node.HLSElement.Attrs, keyOrderAttr, keyShouldQuoteAttr)
 }
 
 func (e MapEncoder) Encode(node *internal.Node, builder *strings.Builder) error {
-	orderAttr := []string{"URI", "BYTERANGE"}
-	shouldQuoteAttr := map[string]bool{
-		"URI":       true,
-		"BYTERANGE": true,
-	}
-	return pl.EncodeTagWithAttributes(builder, MapTag, node.HLSElement.Attrs, orderAttr, shouldQuoteAttr)
+	return pl.EncodeTagWithAttributes(builder, MapTag, node.HLSElement.Attrs, mapOrderAttr, mapShouldQuoteAttr)
 }
 
 func (e GapEncoder) Encode(node *internal.Node, builder *strings.Builder) error {

--- a/tags/media_segment.go
+++ b/tags/media_segment.go
@@ -189,13 +189,19 @@ func (e ExtInfEncoder) Encode(node *internal.Node, builder *strings.Builder) err
 	uri := node.HLSElement.URI
 
 	// #EXTINF:<duration>,[<title>]
+	// Write directly to builder to avoid intermediate string allocations
+	builder.WriteString(ExtInfTag)
+	builder.WriteString(":")
+	builder.WriteString(duration)
 	if title != "" {
-		title = "," + title
+		builder.WriteString(",")
+		builder.WriteString(title)
 	}
+	builder.WriteString("\n")
+	builder.WriteString(uri)
+	builder.WriteString("\n")
 
-	attr := fmt.Sprintf("%s:%s%s\n%s\n", ExtInfTag, duration, title, uri)
-	_, err := builder.WriteString(attr)
-	return err
+	return nil
 }
 
 func (e DiscontinuityEncoder) Encode(node *internal.Node, builder *strings.Builder) error {

--- a/tags/multivariant.go
+++ b/tags/multivariant.go
@@ -31,6 +31,8 @@ var (
 	SessionKeyTag      = "#EXT-X-SESSION-KEY"
 
 	// Pre-allocated shouldQuote maps (avoid allocations in hot path)
+
+	streamInfOrderAttr   = []string{"BANDWIDTH", "AVERAGE-BANDWIDTH", "CODECS", "RESOLUTION", "FRAME-RATE", "HDCP-LEVEL", "VIDEO-RANGE", "AUDIO", "VIDEO", "SUBTITLES", "CLOSED-CAPTIONS"}
 	streamInfShouldQuote = map[string]bool{
 		"BANDWIDTH":         false,
 		"AVERAGE-BANDWIDTH": false,
@@ -45,6 +47,7 @@ var (
 		"CLOSED-CAPTIONS":   true,
 	}
 
+	mediaOrderAttr   = []string{"TYPE", "GROUP-ID", "LANGUAGE", "NAME", "DEFAULT", "AUTOSELECT", "CHANNELS", "URI", "INSTREAM-ID"}
 	mediaShouldQuote = map[string]bool{
 		"TYPE":        false,
 		"GROUP-ID":    true,
@@ -57,6 +60,7 @@ var (
 		"INSTREAM-ID": true,
 	}
 
+	iFrameStreamInfOrderAttr   = []string{"BANDWIDTH", "AVERAGE-BANDWIDTH", "CODECS", "RESOLUTION", "URI", "VIDEO-RANGE", "VIDEO", "SCORE"}
 	iFrameStreamInfShouldQuote = map[string]bool{
 		"BANDWIDTH":         false,
 		"AVERAGE-BANDWIDTH": false,
@@ -68,6 +72,7 @@ var (
 		"SCORE":             false,
 	}
 
+	sessionKeyOrderAttr   = []string{"METHOD", "URI", "IV", "KEYFORMAT", "KEYFORMATVERSIONS"}
 	sessionKeyShouldQuote = map[string]bool{
 		"METHOD":            false,
 		"URI":               true,
@@ -200,8 +205,6 @@ func (p SessionKeyParser) Parse(tag string, playlist *pl.Playlist) error {
 }
 
 func (e StreamInfEncoder) Encode(node *internal.Node, builder *strings.Builder) error {
-	orderAttr := []string{"BANDWIDTH", "AVERAGE-BANDWIDTH", "CODECS", "RESOLUTION", "FRAME-RATE", "HDCP-LEVEL", "VIDEO-RANGE", "AUDIO", "VIDEO", "SUBTITLES", "CLOSED-CAPTIONS"}
-
 	// Use pre-allocated map, only copy for CLOSED-CAPTIONS=NONE case
 	shouldQuoteAttr := streamInfShouldQuote
 	if node.HLSElement.Attrs["CLOSED-CAPTIONS"] == "NONE" {
@@ -213,7 +216,7 @@ func (e StreamInfEncoder) Encode(node *internal.Node, builder *strings.Builder) 
 		shouldQuoteAttr["CLOSED-CAPTIONS"] = false
 	}
 
-	if err := pl.EncodeTagWithAttributes(builder, StreamInfTag, node.HLSElement.Attrs, orderAttr, shouldQuoteAttr); err != nil {
+	if err := pl.EncodeTagWithAttributes(builder, StreamInfTag, node.HLSElement.Attrs, streamInfOrderAttr, shouldQuoteAttr); err != nil {
 		return err
 	}
 	if node.HLSElement.URI != "" {
@@ -224,16 +227,13 @@ func (e StreamInfEncoder) Encode(node *internal.Node, builder *strings.Builder) 
 }
 
 func (e MediaEncoder) Encode(node *internal.Node, builder *strings.Builder) error {
-	orderAttr := []string{"TYPE", "GROUP-ID", "LANGUAGE", "NAME", "DEFAULT", "AUTOSELECT", "CHANNELS", "URI", "INSTREAM-ID"}
-	return pl.EncodeTagWithAttributes(builder, MediaTag, node.HLSElement.Attrs, orderAttr, mediaShouldQuote)
+	return pl.EncodeTagWithAttributes(builder, MediaTag, node.HLSElement.Attrs, mediaOrderAttr, mediaShouldQuote)
 }
 
 func (e IFrameStreamInfEncoder) Encode(node *internal.Node, builder *strings.Builder) error {
-	orderAttr := []string{"BANDWIDTH", "AVERAGE-BANDWIDTH", "CODECS", "RESOLUTION", "URI", "VIDEO-RANGE", "VIDEO", "SCORE"}
-	return pl.EncodeTagWithAttributes(builder, IFrameStreamInfTag, node.HLSElement.Attrs, orderAttr, iFrameStreamInfShouldQuote)
+	return pl.EncodeTagWithAttributes(builder, IFrameStreamInfTag, node.HLSElement.Attrs, iFrameStreamInfOrderAttr, iFrameStreamInfShouldQuote)
 }
 
 func (e SessionKeyEncoder) Encode(node *internal.Node, builder *strings.Builder) error {
-	orderAttr := []string{"METHOD", "URI", "IV", "KEYFORMAT", "KEYFORMATVERSIONS"}
-	return pl.EncodeTagWithAttributes(builder, SessionKeyTag, node.HLSElement.Attrs, orderAttr, sessionKeyShouldQuote)
+	return pl.EncodeTagWithAttributes(builder, SessionKeyTag, node.HLSElement.Attrs, sessionKeyOrderAttr, sessionKeyShouldQuote)
 }

--- a/tags/multivariant.go
+++ b/tags/multivariant.go
@@ -29,6 +29,52 @@ var (
 	MediaTag           = "#EXT-X-MEDIA"
 	IFrameStreamInfTag = "#EXT-X-I-FRAME-STREAM-INF"
 	SessionKeyTag      = "#EXT-X-SESSION-KEY"
+
+	// Pre-allocated shouldQuote maps (avoid allocations in hot path)
+	streamInfShouldQuote = map[string]bool{
+		"BANDWIDTH":         false,
+		"AVERAGE-BANDWIDTH": false,
+		"CODECS":            true,
+		"RESOLUTION":        false,
+		"FRAME-RATE":        false,
+		"HDCP-LEVEL":        false,
+		"VIDEO-RANGE":       false,
+		"AUDIO":             true,
+		"VIDEO":             true,
+		"SUBTITLES":         true,
+		"CLOSED-CAPTIONS":   true,
+	}
+
+	mediaShouldQuote = map[string]bool{
+		"TYPE":        false,
+		"GROUP-ID":    true,
+		"LANGUAGE":    true,
+		"NAME":        true,
+		"DEFAULT":     false,
+		"AUTOSELECT":  false,
+		"CHANNELS":    true,
+		"URI":         true,
+		"INSTREAM-ID": true,
+	}
+
+	iFrameStreamInfShouldQuote = map[string]bool{
+		"BANDWIDTH":         false,
+		"AVERAGE-BANDWIDTH": false,
+		"CODECS":            true,
+		"RESOLUTION":        false,
+		"URI":               true,
+		"VIDEO-RANGE":       false,
+		"VIDEO":             true,
+		"SCORE":             false,
+	}
+
+	sessionKeyShouldQuote = map[string]bool{
+		"METHOD":            false,
+		"URI":               true,
+		"IV":                false,
+		"KEYFORMAT":         true,
+		"KEYFORMATVERSIONS": true,
+	}
 )
 
 type (
@@ -155,80 +201,39 @@ func (p SessionKeyParser) Parse(tag string, playlist *pl.Playlist) error {
 
 func (e StreamInfEncoder) Encode(node *internal.Node, builder *strings.Builder) error {
 	orderAttr := []string{"BANDWIDTH", "AVERAGE-BANDWIDTH", "CODECS", "RESOLUTION", "FRAME-RATE", "HDCP-LEVEL", "VIDEO-RANGE", "AUDIO", "VIDEO", "SUBTITLES", "CLOSED-CAPTIONS"}
-	shouldQuoteAttr := e.shouldQuoteStreamInf(node)
+
+	// Use pre-allocated map, only copy for CLOSED-CAPTIONS=NONE case
+	shouldQuoteAttr := streamInfShouldQuote
+	if node.HLSElement.Attrs["CLOSED-CAPTIONS"] == "NONE" {
+		// Only allocate a new map if we need to modify it
+		shouldQuoteAttr = make(map[string]bool, len(streamInfShouldQuote))
+		for k, v := range streamInfShouldQuote {
+			shouldQuoteAttr[k] = v
+		}
+		shouldQuoteAttr["CLOSED-CAPTIONS"] = false
+	}
 
 	if err := pl.EncodeTagWithAttributes(builder, StreamInfTag, node.HLSElement.Attrs, orderAttr, shouldQuoteAttr); err != nil {
 		return err
 	}
 	if node.HLSElement.URI != "" {
-		_, err := builder.WriteString(node.HLSElement.URI + "\n")
-		return err
+		builder.WriteString(node.HLSElement.URI)
+		builder.WriteByte('\n')
 	}
 	return nil
 }
 
 func (e MediaEncoder) Encode(node *internal.Node, builder *strings.Builder) error {
 	orderAttr := []string{"TYPE", "GROUP-ID", "LANGUAGE", "NAME", "DEFAULT", "AUTOSELECT", "CHANNELS", "URI", "INSTREAM-ID"}
-	shouldQuoteAttr := map[string]bool{
-		"TYPE":        false,
-		"GROUP-ID":    true,
-		"LANGUAGE":    true,
-		"NAME":        true,
-		"DEFAULT":     false,
-		"AUTOSELECT":  false,
-		"CHANNELS":    true,
-		"URI":         true,
-		"INSTREAM-ID": true,
-	}
-	return pl.EncodeTagWithAttributes(builder, MediaTag, node.HLSElement.Attrs, orderAttr, shouldQuoteAttr)
+	return pl.EncodeTagWithAttributes(builder, MediaTag, node.HLSElement.Attrs, orderAttr, mediaShouldQuote)
 }
 
 func (e IFrameStreamInfEncoder) Encode(node *internal.Node, builder *strings.Builder) error {
 	orderAttr := []string{"BANDWIDTH", "AVERAGE-BANDWIDTH", "CODECS", "RESOLUTION", "URI", "VIDEO-RANGE", "VIDEO", "SCORE"}
-	shouldQuoteAttr := map[string]bool{
-		"BANDWIDTH":         false,
-		"AVERAGE-BANDWIDTH": false,
-		"CODECS":            true,
-		"RESOLUTION":        false,
-		"URI":               true,
-		"VIDEO-RANGE":       false,
-		"VIDEO":             true,
-		"SCORE":             false,
-	}
-	return pl.EncodeTagWithAttributes(builder, IFrameStreamInfTag, node.HLSElement.Attrs, orderAttr, shouldQuoteAttr)
+	return pl.EncodeTagWithAttributes(builder, IFrameStreamInfTag, node.HLSElement.Attrs, orderAttr, iFrameStreamInfShouldQuote)
 }
 
 func (e SessionKeyEncoder) Encode(node *internal.Node, builder *strings.Builder) error {
 	orderAttr := []string{"METHOD", "URI", "IV", "KEYFORMAT", "KEYFORMATVERSIONS"}
-	shouldQuoteAttr := map[string]bool{
-		"METHOD":            false,
-		"URI":               true,
-		"IV":                false,
-		"KEYFORMAT":         true,
-		"KEYFORMATVERSIONS": true,
-	}
-	return pl.EncodeTagWithAttributes(builder, SessionKeyTag, node.HLSElement.Attrs, orderAttr, shouldQuoteAttr)
-}
-
-func (e StreamInfEncoder) shouldQuoteStreamInf(node *internal.Node) map[string]bool {
-	shouldQuoteAttr := map[string]bool{
-		"BANDWIDTH":         false,
-		"AVERAGE-BANDWIDTH": false,
-		"CODECS":            true,
-		"RESOLUTION":        false,
-		"FRAME-RATE":        false,
-		"HDCP-LEVEL":        false,
-		"VIDEO-RANGE":       false,
-		"AUDIO":             true,
-		"VIDEO":             true,
-		"SUBTITLES":         true,
-		"CLOSED-CAPTIONS":   true,
-	}
-
-	// the value can be either a quoted-string or an enumerated-string with the value NONE
-	if node.HLSElement.Attrs["CLOSED-CAPTIONS"] == "NONE" {
-		shouldQuoteAttr["CLOSED-CAPTIONS"] = false
-	}
-
-	return shouldQuoteAttr
+	return pl.EncodeTagWithAttributes(builder, SessionKeyTag, node.HLSElement.Attrs, orderAttr, sessionKeyShouldQuote)
 }

--- a/tags/others.go
+++ b/tags/others.go
@@ -26,6 +26,9 @@ var (
 	EventCueOutTag     = "#EXT-X-CUE-OUT"
 	EventCueInTag      = "#EXT-X-CUE-IN"
 	CommentLineTag     = "# comment"
+
+	USPTimestampMapOrderAttr       = []string{"MPEGTS", "LOCAL"}
+	USPTimestampMapShouldQuoteAttr = map[string]bool{"MPEGTS": false, "LOCAL": false}
 )
 
 type (
@@ -104,9 +107,7 @@ func (p CommentParser) Parse(line string, playlist *pl.Playlist) error {
 }
 
 func (e USPTimestampMapEncoder) Encode(node *internal.Node, builder *strings.Builder) error {
-	orderAttr := []string{"MPEGTS", "LOCAL"}
-	shouldQuoteAttr := map[string]bool{"MPEGTS": false, "LOCAL": false}
-	return pl.EncodeTagWithAttributes(builder, USPTimestampMapTag, node.HLSElement.Attrs, orderAttr, shouldQuoteAttr)
+	return pl.EncodeTagWithAttributes(builder, USPTimestampMapTag, node.HLSElement.Attrs, USPTimestampMapOrderAttr, USPTimestampMapShouldQuoteAttr)
 }
 
 func (e EventCueOutEncoder) Encode(node *internal.Node, builder *strings.Builder) error {

--- a/tags/others.go
+++ b/tags/others.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dlclark/regexp2"
 	"github.com/globocom/go-m3u8/internal"
 	pl "github.com/globocom/go-m3u8/playlist"
 	"github.com/rs/zerolog/log"
@@ -27,7 +26,6 @@ var (
 	EventCueOutTag     = "#EXT-X-CUE-OUT"
 	EventCueInTag      = "#EXT-X-CUE-IN"
 	CommentLineTag     = "# comment"
-	CommentLineRegex   = regexp2.MustCompile(`^#(?!(EXT|ext|USP)).*`, 0) // excludes tags (#EXT, #ext or #USP)
 )
 
 type (


### PR DESCRIPTION
## What type of PR is this?

<!-- Select the type of Pull Request below. You may select more than one category if applicable. -->
<!-- If this PR is a draft, remember to create it as such. -->

- [x] 🧹 Refactor: Improves codebase readability and perfomance without adding a new functionality.
- [ ] 💎 Feature: Introduces a new functionality.
- [ ] 🐛 Bug Fix: Patches a bug in the codebase.
- [ ] 📖 Documentation: Adds or updates documentation files.
- [ ] 🧪 CI: Updates CI/CD configuration.
- [ ] 🔙 Revert: Rollbacks previous changes.

## Description

We noticed increased memory usage in some applications using the go-m3u8 library, so a code refactoring was necessary to identify opportunities for improvement.

### What was done:

- **Remove unnecessary allocations:** Removal of fmt.Sprintf(), strings.Join(), strings.Split()

- **Direct writing to the builder:** Use of strings.Builder to accumulate output without intermediate strings

- **Pre-allocation:** Maps and slices pre-allocated with known capacity

- **Removal of regular expressions:** Replacement with simple string comparisons whenever possible


### BEFORE X AFTER IMPROVEMENTS

Comparisons were made using Go's pprof.

<img width="725" height="646" alt="image" src="https://github.com/user-attachments/assets/f1d06b39-d5db-49d7-bcf0-c433b3cd8914" />

<img width="741" height="689" alt="image" src="https://github.com/user-attachments/assets/5379672c-9aad-492e-9fed-b049e7974452" />

<img width="735" height="593" alt="image" src="https://github.com/user-attachments/assets/fe2eb190-c75a-406c-a7d5-86c5fb1c4360" />

<img width="737" height="590" alt="image" src="https://github.com/user-attachments/assets/9709748a-d98e-4b04-8390-4ca1cc3ee380" />



## Related Tickets & Documents

<!-- Describe any relevant related tickets or issues here. When necessary, add further documentation to elaborate on the issue at hand. -->

- **Related Issue:** N/A
- **Closes:** N/A

## Added/Updated Tests?

<!-- We encourage you to keep the code coverage percentage at 80% and above. -->

- [ ] Yes
- [x] No, and this is why: No further adjustments were necessary as there was no change in behavior.
- [ ] I need help with writing tests