### PR TITLE
draft: Add int accessors for sequence tags

### DIFF
--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -67,6 +67,20 @@ func (p *Playlist) VersionValue() string {
 	return node.HLSElement.Attrs["#EXT-X-VERSION"]
 }
 
+// Returns the Version (#EXT-X-VERSION) tag's value as an integer. If the tag is not found or the value cannot be parsed as an integer, returns 0 and an error.
+func (p *Playlist) VersionIntValue() (int, error) {
+	versionStr := p.VersionValue()
+	if versionStr == "" {
+		return 0, errors.New("version tag not found")
+	}
+	var version int
+	_, err := fmt.Sscanf(versionStr, "%d", &version)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse version value: %w", err)
+	}
+	return version, nil
+}
+
 // Returns the Version (#EXT-X-VERSION) tag as a Node if it exists, otherwise returns nil and false
 func (p *Playlist) VersionTag() (*internal.Node, bool) {
 	return p.Find("Version")
@@ -81,6 +95,20 @@ func (p *Playlist) MediaSequenceValue() string {
 	return node.HLSElement.Attrs["#EXT-X-MEDIA-SEQUENCE"]
 }
 
+// Returns the MediaSequence (#EXT-X-MEDIA-SEQUENCE) tag's value as an integer. If the tag is not found or the value cannot be parsed as an integer, returns 0 and an error.
+func (p *Playlist) MediaSequenceIntValue() (int, error) {
+	sequenceStr := p.MediaSequenceValue()
+	if sequenceStr == "" {
+		return 0, errors.New("media sequence tag not found")
+	}
+	var sequence int
+	_, err := fmt.Sscanf(sequenceStr, "%d", &sequence)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse media sequence value: %w", err)
+	}
+	return sequence, nil
+}
+
 // Returns the MediaSequence (#EXT-X-MEDIA-SEQUENCE) tag as a Node if it exists, otherwise returns nil and false
 func (p *Playlist) MediaSequenceTag() (*internal.Node, bool) {
 	return p.Find("MediaSequence")
@@ -93,6 +121,20 @@ func (p *Playlist) DiscontinuitySequenceValue() string {
 		return ""
 	}
 	return node.HLSElement.Attrs["#EXT-X-DISCONTINUITY-SEQUENCE"]
+}
+
+// Returns the DiscontinuitySequence (#EXT-X-DISCONTINUITY-SEQUENCE) tag's value as an integer. If the tag is not found or the value cannot be parsed as an integer, returns 0 and an error.
+func (p *Playlist) DiscontinuitySequenceIntValue() (int, error) {
+	sequenceStr := p.DiscontinuitySequenceValue()
+	if sequenceStr == "" {
+		return 0, errors.New("discontinuity sequence tag not found")
+	}
+	var sequence int
+	_, err := fmt.Sscanf(sequenceStr, "%d", &sequence)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse discontinuity sequence value: %w", err)
+	}
+	return sequence, nil
 }
 
 // Returns the DiscontinuitySequence (#EXT-X-DISCONTINUITY-SEQUENCE) tag as a Node if it exists, otherwise returns nil and false

--- a/playlist/playlist_test.go
+++ b/playlist/playlist_test.go
@@ -20,6 +20,41 @@ func TestVersionValue(t *testing.T) {
 	assert.Equal(t, version, "3")
 }
 
+func TestVersionIntValue(t *testing.T) {
+	file, _ := os.Open("./../mocks/media/media.m3u8")
+	playlist, err := m3u8.ParsePlaylist(file)
+	assert.NoError(t, err)
+
+	version, err := playlist.VersionIntValue()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, version)
+}
+
+func TestVersionIntValueMissingTag(t *testing.T) {
+	file, _ := os.Open("./../mocks/media/multivariant.m3u8")
+	playlist, err := m3u8.ParsePlaylist(file)
+	assert.NoError(t, err)
+
+	version, err := playlist.VersionIntValue()
+	assert.Error(t, err)
+	assert.Equal(t, 0, version)
+}
+
+func TestVersionIntValueInvalidValue(t *testing.T) {
+	file, _ := os.Open("./../mocks/media/media.m3u8")
+	playlist, err := m3u8.ParsePlaylist(file)
+	assert.NoError(t, err)
+
+	node, found := playlist.VersionTag()
+	assert.True(t, found)
+	assert.NotNil(t, node)
+	node.HLSElement.Attrs["#EXT-X-VERSION"] = "abc"
+
+	version, err := playlist.VersionIntValue()
+	assert.Error(t, err)
+	assert.Equal(t, 0, version)
+}
+
 func TestVersionTag(t *testing.T) {
 	file, _ := os.Open("./../mocks/media/media.m3u8")
 	playlist, err := m3u8.ParsePlaylist(file)
@@ -40,6 +75,41 @@ func TestMediaSequenceValue(t *testing.T) {
 	assert.Equal(t, mediaSequence, "364042169")
 }
 
+func TestMediaSequenceIntValue(t *testing.T) {
+	file, _ := os.Open("./../mocks/media/media.m3u8")
+	playlist, err := m3u8.ParsePlaylist(file)
+	assert.NoError(t, err)
+
+	mediaSequence, err := playlist.MediaSequenceIntValue()
+	assert.NoError(t, err)
+	assert.Equal(t, 364042169, mediaSequence)
+}
+
+func TestMediaSequenceIntValueMissingTag(t *testing.T) {
+	file, _ := os.Open("./../mocks/multivariant/multivariant.m3u8")
+	playlist, err := m3u8.ParsePlaylist(file)
+	assert.NoError(t, err)
+
+	mediaSequence, err := playlist.MediaSequenceIntValue()
+	assert.Error(t, err)
+	assert.Equal(t, 0, mediaSequence)
+}
+
+func TestMediaSequenceIntValueInvalidValue(t *testing.T) {
+	file, _ := os.Open("./../mocks/media/media.m3u8")
+	playlist, err := m3u8.ParsePlaylist(file)
+	assert.NoError(t, err)
+
+	node, found := playlist.MediaSequenceTag()
+	assert.True(t, found)
+	assert.NotNil(t, node)
+	node.HLSElement.Attrs["#EXT-X-MEDIA-SEQUENCE"] = "abc"
+
+	mediaSequence, err := playlist.MediaSequenceIntValue()
+	assert.Error(t, err)
+	assert.Equal(t, 0, mediaSequence)
+}
+
 func TestMediaSequenceTag(t *testing.T) {
 	file, _ := os.Open("./../mocks/media/media.m3u8")
 	playlist, err := m3u8.ParsePlaylist(file)
@@ -58,6 +128,41 @@ func TestDiscontinuitySequenceValue(t *testing.T) {
 
 	discSequence := playlist.DiscontinuitySequenceValue()
 	assert.Equal(t, discSequence, "87498")
+}
+
+func TestDiscontinuitySequenceIntValue(t *testing.T) {
+	file, _ := os.Open("./../mocks/media/withDiscontinuity.m3u8")
+	playlist, err := m3u8.ParsePlaylist(file)
+	assert.NoError(t, err)
+
+	discSequence, err := playlist.DiscontinuitySequenceIntValue()
+	assert.NoError(t, err)
+	assert.Equal(t, 87498, discSequence)
+}
+
+func TestDiscontinuitySequenceIntValueMissingTag(t *testing.T) {
+	file, _ := os.Open("./../mocks/multivariant/multivariant.m3u8")
+	playlist, err := m3u8.ParsePlaylist(file)
+	assert.NoError(t, err)
+
+	discSequence, err := playlist.DiscontinuitySequenceIntValue()
+	assert.Error(t, err)
+	assert.Equal(t, 0, discSequence)
+}
+
+func TestDiscontinuitySequenceIntValueInvalidValue(t *testing.T) {
+	file, _ := os.Open("./../mocks/media/withDiscontinuity.m3u8")
+	playlist, err := m3u8.ParsePlaylist(file)
+	assert.NoError(t, err)
+
+	node, found := playlist.DiscontinuitySequenceTag()
+	assert.True(t, found)
+	assert.NotNil(t, node)
+	node.HLSElement.Attrs["#EXT-X-DISCONTINUITY-SEQUENCE"] = "abc"
+
+	discSequence, err := playlist.DiscontinuitySequenceIntValue()
+	assert.Error(t, err)
+	assert.Equal(t, 0, discSequence)
 }
 
 func TestDiscontinuitySequenceTag(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] 🧹 Refactor: Improves codebase readability and perfomance without adding a new functionality.
- [x] 💎 Feature: Introduces a new functionality.
- [ ] 🐛 Bug Fix: Patches a bug in the codebase.
- [ ] 📖 Documentation: Adds or updates documentation files.
- [ ] 🧪 CI: Updates CI/CD configuration.
- [ ] 🔙 Revert: Rollbacks previous changes.

## Description

Add int accessors for tags `Version` `MediaSequence` and `DiscontinuitySequence`.


## QA Instructions & Examples

```
file, _ := os.Open("./../mocks/media/media.m3u8")
playlist, err := m3u8.ParsePlaylist(file)
version, _ := playlist.VersionIntValue()
fmt.Printf("Playlist version is: %d", version)
```

## Added/Updated Tests?

Yes