### PR TITLE
feat(playlist): add manifest filters and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,91 @@ if err != nil {
 
 For complete details on the available methods, please read [the original release notes](https://github.com/globocom/go-m3u8/releases/tag/v0.1.0).
 
+### Manifest Filters
+
+The `Playlist` type provides filter methods for multivariant and media playlists.
+
+Available filters:
+
+- `FilterByMaxHeight(maxHeight int)`
+- `FilterByMinHeight(minHeight int)`
+- `FilterByMaxWidth(maxWidth int)`
+- `FilterByMinWidth(minWidth int)`
+- `FilterByMaxBitrate(maxBitrate int)`
+- `FilterByMinBitrate(minBitrate int)`
+- `FilterByDVRWindow(dvrWindowSeconds float64)`
+
+Notes:
+
+- Height/width/bitrate filters apply to multivariant playlists (`#EXT-X-STREAM-INF` variants).
+- `FilterByDVRWindow` applies to media playlists (`#EXTINF` segments).
+- You can combine filters by calling them in sequence.
+
+#### Example: Filter a Multivariant Playlist
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+
+	go_m3u8 "github.com/globocom/go-m3u8"
+)
+
+func main() {
+	file, _ := os.Open("multivariant.m3u8")
+	p, err := go_m3u8.ParsePlaylist(file)
+	if err != nil {
+		panic(err)
+	}
+
+	// Keep only variants in the desired quality/bitrate range.
+	p.FilterByMinHeight(720)
+	p.FilterByMaxWidth(1280)
+	p.FilterByMinBitrate(700000)
+	p.FilterByMaxBitrate(2000000)
+
+	manifest, err := go_m3u8.EncodePlaylist(p)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(manifest)
+}
+```
+
+#### Example: Filter a Media Playlist by DVR Window
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+
+	go_m3u8 "github.com/globocom/go-m3u8"
+)
+
+func main() {
+	file, _ := os.Open("media.m3u8")
+	p, err := go_m3u8.ParsePlaylist(file)
+	if err != nil {
+		panic(err)
+	}
+
+	// Keep only the most recent 20 seconds of segments.
+	p.FilterByDVRWindow(20)
+
+	manifest, err := go_m3u8.EncodePlaylist(p)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(manifest)
+}
+```
+
 ### Collecting Ad Break Data
 
 Collect information on ad breaks present on the manifest when SCTE-35 ad insertion is used.

--- a/playlist/filters.go
+++ b/playlist/filters.go
@@ -3,27 +3,216 @@ package playlist
 import (
 	"strconv"
 	"strings"
+	"time"
 )
 
+// Parses a resolution string in the format "WIDTHxHEIGHT"
+// returns the width, height, and a boolean indicating success.
+func parseResolution(resolution string) (int, int, bool) {
+	if resolution == "" {
+		return 0, 0, false
+	}
+
+	parts := strings.Split(resolution, "x")
+	if len(parts) != 2 {
+		return 0, 0, false
+	}
+
+	width, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, false
+	}
+
+	height, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, false
+	}
+
+	return width, height, true
+}
+
+// Parses an integer attribute from a string
+// returning the parsed value and a boolean indicating success.
+func parseIntAttr(value string) (int, bool) {
+	if value == "" {
+		return 0, false
+	}
+
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, false
+	}
+
+	return parsed, true
+}
+
+// Parses a float attribute from a string
+// returning the parsed value and a boolean indicating success.
+func parseFloatAttr(value string) (float64, bool) {
+	if value == "" {
+		return 0, false
+	}
+
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, false
+	}
+
+	return parsed, true
+}
+
+// Master Manifest filters
 // Removes all variant streams (#EXT-X-STREAM-INF) from the playlist that exceed the given maxHeight.
 func (p *Playlist) FilterByMaxHeight(maxHeight int) {
 	nodes := p.Variants()
 	for i := range nodes {
-		resolution := nodes[i].HLSElement.Attrs["RESOLUTION"]
-		if resolution == "" {
-			continue
-		}
-		parts := strings.Split(resolution, "x")
-		if len(parts) != 2 {
-			continue
-		}
-		heightStr := parts[1]
-		height, err := strconv.Atoi(heightStr)
-		if err != nil {
+		_, height, ok := parseResolution(nodes[i].HLSElement.Attrs["RESOLUTION"])
+		if !ok {
 			continue
 		}
 		if height > maxHeight {
 			p.Remove(nodes[i])
 		}
 	}
+}
+
+// Removes all variant streams (#EXT-X-STREAM-INF) from the playlist that are below the given minHeight.
+func (p *Playlist) FilterByMinHeight(minHeight int) {
+	nodes := p.Variants()
+	for i := range nodes {
+		_, height, ok := parseResolution(nodes[i].HLSElement.Attrs["RESOLUTION"])
+		if !ok {
+			continue
+		}
+		if height < minHeight {
+			p.Remove(nodes[i])
+		}
+	}
+}
+
+// Removes all variant streams (#EXT-X-STREAM-INF) from the playlist that exceed the given maxWidth.
+func (p *Playlist) FilterByMaxWidth(maxWidth int) {
+	nodes := p.Variants()
+	for i := range nodes {
+		width, _, ok := parseResolution(nodes[i].HLSElement.Attrs["RESOLUTION"])
+		if !ok {
+			continue
+		}
+		if width > maxWidth {
+			p.Remove(nodes[i])
+		}
+	}
+}
+
+// Removes all variant streams (#EXT-X-STREAM-INF) from the playlist that are below the given minWidth.
+func (p *Playlist) FilterByMinWidth(minWidth int) {
+	nodes := p.Variants()
+	for i := range nodes {
+		width, _, ok := parseResolution(nodes[i].HLSElement.Attrs["RESOLUTION"])
+		if !ok {
+			continue
+		}
+		if width < minWidth {
+			p.Remove(nodes[i])
+		}
+	}
+}
+
+// Removes all variant streams (#EXT-X-STREAM-INF) from the playlist that exceed the given maxBitrate.
+func (p *Playlist) FilterByMaxBitrate(maxBitrate int) {
+	nodes := p.Variants()
+	for i := range nodes {
+		bitrate, ok := parseIntAttr(nodes[i].HLSElement.Attrs["BANDWIDTH"])
+		if !ok {
+			continue
+		}
+		if bitrate > maxBitrate {
+			p.Remove(nodes[i])
+		}
+	}
+}
+
+// Removes all variant streams (#EXT-X-STREAM-INF) from the playlist that are below the given minBitrate.
+func (p *Playlist) FilterByMinBitrate(minBitrate int) {
+	nodes := p.Variants()
+	for i := range nodes {
+		bitrate, ok := parseIntAttr(nodes[i].HLSElement.Attrs["BANDWIDTH"])
+		if !ok {
+			continue
+		}
+		if bitrate < minBitrate {
+			p.Remove(nodes[i])
+		}
+	}
+}
+
+// Media Manifest filters
+// Removes older media timeline entries to keep only the most recent dvrWindowSeconds of segments.
+func (p *Playlist) FilterByDVRWindow(dvrWindowSeconds float64) {
+	if dvrWindowSeconds <= 0 {
+		return
+	}
+
+	segments := p.Segments()
+	if len(segments) == 0 {
+		return
+	}
+
+	keptStartIdx := len(segments) - 1
+	cumulativeDuration := 0.0
+
+	for i := len(segments) - 1; i >= 0; i-- {
+		duration, ok := parseFloatAttr(segments[i].HLSElement.Attrs["Duration"])
+		if !ok {
+			continue
+		}
+
+		if cumulativeDuration+duration > dvrWindowSeconds {
+			break
+		}
+
+		cumulativeDuration = RoundFloat(cumulativeDuration+duration, 4)
+		keptStartIdx = i
+	}
+
+	if keptStartIdx == 0 {
+		return
+	}
+
+	oldestSegment := segments[0]
+	newOldestSegment := segments[keptStartIdx]
+
+	current := oldestSegment
+	for current != nil && current != newOldestSegment {
+		next := current.Next
+		p.Remove(current)
+		current = next
+	}
+
+	if mediaSequence, ok := parseIntAttr(newOldestSegment.HLSElement.Details["MediaSequence"]); ok {
+		if mediaSequenceTag, found := p.MediaSequenceTag(); found {
+			mediaSequenceTag.HLSElement.Attrs["#EXT-X-MEDIA-SEQUENCE"] = strconv.Itoa(mediaSequence)
+		}
+		p.MediaSequence = mediaSequence
+	}
+
+	if segmentPDT, err := time.Parse(time.RFC3339Nano, newOldestSegment.HLSElement.Details["ProgramDateTime"]); err == nil {
+		if pdtTag, found := p.Find("ProgramDateTime"); found {
+			pdtTag.HLSElement.Attrs["#EXT-X-PROGRAM-DATE-TIME"] = segmentPDT.Format(time.RFC3339Nano)
+		}
+		p.ProgramDateTime = segmentPDT
+	}
+
+	updatedSegments := p.Segments()
+	updatedDVR := 0.0
+	for i := range updatedSegments {
+		duration, ok := parseFloatAttr(updatedSegments[i].HLSElement.Attrs["Duration"])
+		if !ok {
+			continue
+		}
+		updatedDVR = RoundFloat(updatedDVR+duration, 4)
+	}
+
+	p.SegmentsCounter = len(updatedSegments)
+	p.DVR = updatedDVR
 }

--- a/playlist/filters.go
+++ b/playlist/filters.go
@@ -8,7 +8,7 @@ import (
 
 // Parses a resolution string in the format "WIDTHxHEIGHT"
 // returns the width, height, and a boolean indicating success.
-func parseResolution(resolution string) (int, int, bool) {
+func parseResolution(resolution string) (width, height int, ok bool) {
 	if resolution == "" {
 		return 0, 0, false
 	}
@@ -23,7 +23,7 @@ func parseResolution(resolution string) (int, int, bool) {
 		return 0, 0, false
 	}
 
-	height, err := strconv.Atoi(parts[1])
+	height, err = strconv.Atoi(parts[1])
 	if err != nil {
 		return 0, 0, false
 	}

--- a/playlist/filters_test.go
+++ b/playlist/filters_test.go
@@ -1,0 +1,130 @@
+package playlist_test
+
+import (
+	"os"
+	"testing"
+
+	m3u8 "github.com/globocom/go-m3u8"
+	"github.com/stretchr/testify/assert"
+)
+
+// Master Manifest filters
+func TestVariantsHeightFilter(t *testing.T) {
+	file, _ := os.Open("./../mocks/multivariant/multivariant.m3u8")
+	playlist, err := m3u8.ParsePlaylist(file)
+	assert.NoError(t, err)
+
+	playlist.FilterByMaxHeight(720)
+	nodes := playlist.Variants()
+	assert.NotNil(t, nodes)
+	assert.Len(t, nodes, 7)
+}
+
+func TestVariantsMinHeightFilter(t *testing.T) {
+	file, _ := os.Open("./../mocks/multivariant/multivariant.m3u8")
+	playlist, err := m3u8.ParsePlaylist(file)
+	assert.NoError(t, err)
+
+	playlist.FilterByMinHeight(720)
+	nodes := playlist.Variants()
+	assert.NotNil(t, nodes)
+	assert.Len(t, nodes, 3)
+}
+
+func TestVariantsMaxWidthFilter(t *testing.T) {
+	file, _ := os.Open("./../mocks/multivariant/multivariant.m3u8")
+	playlist, err := m3u8.ParsePlaylist(file)
+	assert.NoError(t, err)
+
+	playlist.FilterByMaxWidth(1280)
+	nodes := playlist.Variants()
+	assert.NotNil(t, nodes)
+	assert.Len(t, nodes, 7)
+}
+
+func TestVariantsMinWidthFilter(t *testing.T) {
+	file, _ := os.Open("./../mocks/multivariant/multivariant.m3u8")
+	playlist, err := m3u8.ParsePlaylist(file)
+	assert.NoError(t, err)
+
+	playlist.FilterByMinWidth(768)
+	nodes := playlist.Variants()
+	assert.NotNil(t, nodes)
+	assert.Len(t, nodes, 4)
+}
+
+func TestVariantsMixedFiltersMinHeightAndMaxWidth(t *testing.T) {
+	file, _ := os.Open("./../mocks/multivariant/multivariant.m3u8")
+	playlist, err := m3u8.ParsePlaylist(file)
+	assert.NoError(t, err)
+
+	playlist.FilterByMinHeight(720)
+	playlist.FilterByMaxWidth(1280)
+	nodes := playlist.Variants()
+	assert.NotNil(t, nodes)
+	assert.Len(t, nodes, 2)
+}
+
+func TestVariantsMixedFiltersMinWidthMaxWidthAndMinHeight(t *testing.T) {
+	file, _ := os.Open("./../mocks/multivariant/multivariant.m3u8")
+	playlist, err := m3u8.ParsePlaylist(file)
+	assert.NoError(t, err)
+
+	playlist.FilterByMinWidth(500)
+	playlist.FilterByMaxWidth(1000)
+	playlist.FilterByMinHeight(300)
+	nodes := playlist.Variants()
+	assert.NotNil(t, nodes)
+	assert.Len(t, nodes, 2)
+}
+
+func TestVariantsMaxBitrateFilter(t *testing.T) {
+	file, _ := os.Open("./../mocks/multivariant/multivariant.m3u8")
+	playlist, err := m3u8.ParsePlaylist(file)
+	assert.NoError(t, err)
+
+	playlist.FilterByMaxBitrate(1000000)
+	nodes := playlist.Variants()
+	assert.NotNil(t, nodes)
+	assert.Len(t, nodes, 4)
+}
+
+func TestVariantsMinBitrateFilter(t *testing.T) {
+	file, _ := os.Open("./../mocks/multivariant/multivariant.m3u8")
+	playlist, err := m3u8.ParsePlaylist(file)
+	assert.NoError(t, err)
+
+	playlist.FilterByMinBitrate(1000000)
+	nodes := playlist.Variants()
+	assert.NotNil(t, nodes)
+	assert.Len(t, nodes, 4)
+}
+
+func TestVariantsMixedFiltersMinAndMaxBitrate(t *testing.T) {
+	file, _ := os.Open("./../mocks/multivariant/multivariant.m3u8")
+	playlist, err := m3u8.ParsePlaylist(file)
+	assert.NoError(t, err)
+
+	playlist.FilterByMinBitrate(700000)
+	playlist.FilterByMaxBitrate(2000000)
+	nodes := playlist.Variants()
+	assert.NotNil(t, nodes)
+	assert.Len(t, nodes, 3)
+}
+
+// Media Manifest filters
+func TestFilterByDVRWindow(t *testing.T) {
+	file, _ := os.Open("./../mocks/media/media.m3u8")
+	playlist, err := m3u8.ParsePlaylist(file)
+	assert.NoError(t, err)
+
+	playlist.FilterByDVRWindow(20)
+	segments := playlist.Segments()
+	assert.NotNil(t, segments)
+	assert.Len(t, segments, 4)
+	assert.Equal(t, "channel-audio_1=96000-video=3442944-364042192.ts", segments[0].HLSElement.URI)
+	assert.Equal(t, "channel-audio_1=96000-video=3442944-364042195.ts", segments[3].HLSElement.URI)
+	assert.Equal(t, "364042192", playlist.MediaSequenceValue())
+	assert.Equal(t, 364042192, playlist.MediaSequence)
+	assert.Equal(t, 19.2, playlist.DVR)
+}

--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -337,3 +337,25 @@ func (p *Playlist) removeDuplicateBreakTags(adBreak *internal.Node) {
 
 	p.Remove(adBreak)
 }
+
+// Ensures that the playlist's HLS version is at least the specified minimum version.
+// It returns the Version tag node (which may have been updated, if it exists)
+func (p *Playlist) EnsureHLSVersion(minVersion int) *internal.Node {
+	versionNode, found := p.VersionTag()
+	if !found {
+		return nil
+	}
+
+	versionStr := versionNode.HLSElement.Attrs["#EXT-X-VERSION"]
+	var version int
+	_, err := fmt.Sscanf(versionStr, "%d", &version)
+	if err != nil {
+		return nil
+	}
+
+	if version < minVersion {
+		versionNode.HLSElement.Attrs["#EXT-X-VERSION"] = fmt.Sprintf("%d", minVersion)
+	}
+
+	return versionNode
+}

--- a/playlist/playlist_test.go
+++ b/playlist/playlist_test.go
@@ -92,17 +92,6 @@ func TestVariants(t *testing.T) {
 	assert.Len(t, nodes, 8)
 }
 
-func TestVariantsHeightFilter(t *testing.T) {
-	file, _ := os.Open("./../mocks/multivariant/multivariant.m3u8")
-	playlist, err := m3u8.ParsePlaylist(file)
-	assert.NoError(t, err)
-
-	playlist.FilterByMaxHeight(720)
-	nodes := playlist.Variants()
-	assert.NotNil(t, nodes)
-	assert.Len(t, nodes, 7)
-}
-
 func TestMediaGroups(t *testing.T) {
 	file, _ := os.Open("./../mocks/multivariant/withClosedCaptionGroups.m3u8")
 	playlist, err := m3u8.ParsePlaylist(file)

--- a/tags/basic.go
+++ b/tags/basic.go
@@ -52,6 +52,7 @@ func (p VersionParser) Parse(tag string, playlist *pl.Playlist) error {
 				Attrs: map[string]string{VersionTag: strings.TrimSpace(parts[1])},
 			},
 		})
+
 		return nil
 	}
 	return fmt.Errorf("invalid version tag: %s", tag)


### PR DESCRIPTION
## Summary
- add new playlist filters for variant constraints: min/max height, min/max width, min/max bitrate
- add media playlist filter for DVR window trimming (`FilterByDVRWindow`)
- add dedicated filter tests in `playlist/filters_test.go`
- document filter options and usage examples in `README.md`

## Validation
- `go test ./playlist -run 'TestVariants|TestFilterByDVRWindow'`

## Notes
- branch: `add-manifest-filters`
- commit: `e2af03a`